### PR TITLE
Update JTS and Spatial4j Dependencies

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,11 @@
+# Changelog
+
+## 1.0.0 to 1.1.0
+
+* Update dependencies, including JTS to 1.13 and Spatial4J to 0.6
+* Add new `geo.io` namespace with functions for reading and writing common geo formats
+* Fix intersecting-geohashes edge cases around dateline and origin-crossing geometries
+
+We'll also be tracking the ongoing JTS migration as the project moves from `com.vividsolutions` into `org.locationtech`. We'll try to put out another release with the latest JTS/Spatial4J versions once that is sorted out.
+
+More info: https://github.com/locationtech/jts/issues/78

--- a/README.md
+++ b/README.md
@@ -73,7 +73,7 @@ user=> (geohash/geohash-midline-dimensions h)
 [152.7895756415971 95.34671939564083]
 
 ; As a base32-encoded string, this hash is:
-user=> (geohash/sstring h)
+user=> (geohash/string h)
 "u10j4bs"
 
 ; We can drop characters off a geohash to get strict supersets of that hash.
@@ -101,7 +101,6 @@ user=> (-> (iterate geohash/northern-neighbor h) (nth 5) (spatial/relate h))
 ; Or more directly
 user=> (map geohash/string (geohash/geohashes-near lhr 1000 30))
 ("gcpsv3" "gcpsv4" "gcpsv5" "gcpsv6" "gcpsv7" "gcpsv9" "gcpsvd" "gcpsve" "gcpsvf" "gcpsvg" "gcpsvh" "gcpsvk" "gcpsvs" "gcpsvu")
-
 ```
 
 # Namespace overview

--- a/README.md
+++ b/README.md
@@ -32,7 +32,7 @@ Install via [clojars](https://clojars.org/factual/geo)
 
 ```clj
 ; Load library
-(require '[geo [geohash :as geohash] [jts :as jts] [spatial :as spatial]])
+(require '[geo [geohash :as geohash] [jts :as jts] [spatial :as spatial] [io :as gio]])
 
 ; Find the earth's radius at the pole, in meters
 user=> (spatial/earth-radius spatial/south-pole)
@@ -101,6 +101,25 @@ user=> (-> (iterate geohash/northern-neighbor h) (nth 5) (spatial/relate h))
 ; Or more directly
 user=> (map geohash/string (geohash/geohashes-near lhr 1000 30))
 ("gcpsv3" "gcpsv4" "gcpsv5" "gcpsv6" "gcpsv7" "gcpsv9" "gcpsvd" "gcpsve" "gcpsvf" "gcpsvg" "gcpsvh" "gcpsvk" "gcpsvs" "gcpsvu")
+
+; Reading JTS Geometries to/from common geo formats
+user=> (gio/read-wkt "POLYGON ((-70 30, -70 30, -70 30, -70 30, -70 30))")
+#object[com.vividsolutions.jts.geom.Polygon 0x675302a "POLYGON ((-70 30, -70 30, -70 30, -70 30, -70 30))"]
+
+user=> (gio/to-wkt (gio/read-wkt "POLYGON ((-70 30, -70 31, -71 31, -71 30, -70 30))"))
+"POLYGON ((-70 30, -70 31, -71 31, -71 30, -70 30))"
+
+user=> (gio/read-geojson "{\"type\":\"Polygon\",\"coordinates\":[[[-70.0,30.0],[-70.0,31.0],[-71.0,31.0],[-71.0,30.0],[-70.0,30.0]]]}")
+#object[com.vividsolutions.jts.geom.Polygon 0x57a1c5f5 "POLYGON ((-70 30, -70 31, -71 31, -71 30, -70 30))"]
+
+user=> (gio/to-geojson (gio/read-geojson "{\"type\":\"Polygon\",\"coordinates\":[[[-70.0,30.0],[-70.0,31.0],[-71.0,31.0],[-71.0,30.0],[-70.0,30.0]]]}"))
+"{\"type\":\"Polygon\",\"coordinates\":[[[-70.0,30.0],[-70.0,31.0],[-71.0,31.0],[-71.0,30.0],[-70.0,30.0]]]}"
+
+user=> (gio/to-wkb (gio/read-wkt "POLYGON ((-70 30, -70 31, -71 31, -71 30, -70 30))"))
+#object["[B" 0xe62e731 "[B@e62e731"]
+
+user=> (gio/read-wkb *1)
+#object[com.vividsolutions.jts.geom.Polygon 0x6f85711c "POLYGON ((-70 30, -70 31, -71 31, -71 30, -70 30))"]
 ```
 
 # Namespace overview
@@ -152,6 +171,12 @@ Given a target shape on the geoid, can tell you how many bits of precision are
 necessary to get geohashes on roughly that scale. Can compute all geohashes
 intersecting a shape in general, and all geohashes within a radius of a point
 in specific.
+
+## geo.io
+
+Helper functions for dealing with common geospatial serialization formats. Use these to read and write from WKT, GeoJSON, and WKB.
+
+IO functions return and accept JTS Geometries.
 
 # Tests
 

--- a/README.md
+++ b/README.md
@@ -28,6 +28,12 @@ hope that it can be a canonical resource for geospatial computation in Clojure.
 
 Install via [clojars](https://clojars.org/factual/geo)
 
+Leiningen Dependency Vector:
+
+```
+[factual/geo "1.1.0"]
+```
+
 # Examples
 
 ```clj
@@ -176,7 +182,7 @@ in specific.
 
 Helper functions for dealing with common geospatial serialization formats. Use these to read and write from WKT, GeoJSON, and WKB.
 
-IO functions return and accept JTS Geometries.
+IO functions return JTS Geometries.
 
 # Tests
 

--- a/README.md
+++ b/README.md
@@ -28,6 +28,8 @@ hope that it can be a canonical resource for geospatial computation in Clojure.
 
 Install via [clojars](https://clojars.org/factual/geo)
 
+[![Clojars Project](https://img.shields.io/clojars/v/factual/geo.svg)](https://clojars.org/factual/geo)
+
 Leiningen Dependency Vector:
 
 ```

--- a/project.clj
+++ b/project.clj
@@ -7,12 +7,11 @@
             :comments "same as Clojure"}
   :description "Geospatial operations over points, lines, polys, geohashes, etc.o"
   :dependencies
-  [[org.clojure/math.numeric-tower "0.0.2"]
+  [[org.clojure/math.numeric-tower "0.0.4"]
    [la.tomoj/geohash-java "1.0.6"]
-   [com.spatial4j/spatial4j "0.3"]
-   ; JTS depends on an ancient version of xerces which breaks hadoop
-   [com.vividsolutions/jts "1.11" :exclusions [xerces/xercesImpl]]]
+   [org.locationtech.spatial4j/spatial4j "0.6"]
+   [com.vividsolutions/jts "1.13"]]
   :profiles {:dev {:plugins [[lein-midje "3.1.1"]]
-                   :dependencies [[org.clojure/clojure "1.6.0"]
+                   :dependencies [[org.clojure/clojure "1.8.0"]
                                   [midje "1.6.3"]
-                                  [midje-cascalog "0.4.0"]]}})
+                                  [midje-cascalog "0.4.0" :exclusions [org.clojure/clojure]]]}})

--- a/project.clj
+++ b/project.clj
@@ -8,7 +8,7 @@
   :description "Geospatial operations over points, lines, polys, geohashes, etc.o"
   :dependencies
   [[org.clojure/math.numeric-tower "0.0.4"]
-   [la.tomoj/geohash-java "1.0.6"]
+   [ch.hsr/geohash "1.3.0"]
    [org.locationtech.spatial4j/spatial4j "0.6"]
    [com.vividsolutions/jts "1.13"]]
   :profiles {:dev {:plugins [[lein-midje "3.1.1"]]

--- a/project.clj
+++ b/project.clj
@@ -1,5 +1,5 @@
 (defproject
-  factual/geo "1.0.0"
+  factual/geo "1.1.0"
   :url     "https://github.com/factual/geo"
   :license {:name "Eclipse Public License - v 1.0"
             :url  "http://www.eclipse.org/legal/epl-v10.html"
@@ -13,5 +13,4 @@
    [com.vividsolutions/jts "1.13"]]
   :profiles {:dev {:plugins [[lein-midje "3.1.1"]]
                    :dependencies [[org.clojure/clojure "1.8.0"]
-                                  [midje "1.6.3"]
-                                  [midje-cascalog "0.4.0" :exclusions [org.clojure/clojure]]]}})
+                                  [midje "1.6.3"]]}})

--- a/project.clj
+++ b/project.clj
@@ -15,4 +15,5 @@
    [org.noggit/noggit "0.8"]]
   :profiles {:dev {:plugins [[lein-midje "3.1.1"]]
                    :dependencies [[org.clojure/clojure "1.8.0"]
+                                  [criterium "0.4.4"]
                                   [midje "1.6.3"]]}})

--- a/project.clj
+++ b/project.clj
@@ -1,5 +1,5 @@
 (defproject
-  factual/geo "1.2.0-SNAPSHOT"
+  factual/geo "1.1.0"
   :url     "https://github.com/factual/geo"
   :license {:name "Eclipse Public License - v 1.0"
             :url  "http://www.eclipse.org/legal/epl-v10.html"

--- a/project.clj
+++ b/project.clj
@@ -1,5 +1,5 @@
 (defproject
-  factual/geo "1.1.0"
+  factual/geo "1.2.0-SNAPSHOT"
   :url     "https://github.com/factual/geo"
   :license {:name "Eclipse Public License - v 1.0"
             :url  "http://www.eclipse.org/legal/epl-v10.html"
@@ -10,7 +10,9 @@
   [[org.clojure/math.numeric-tower "0.0.4"]
    [ch.hsr/geohash "1.3.0"]
    [org.locationtech.spatial4j/spatial4j "0.6"]
-   [com.vividsolutions/jts "1.13"]]
+   [com.vividsolutions/jts "1.13"]
+   [org.wololo/jts2geojson "0.10.0"]
+   [org.noggit/noggit "0.8"]]
   :profiles {:dev {:plugins [[lein-midje "3.1.1"]]
                    :dependencies [[org.clojure/clojure "1.8.0"]
                                   [midje "1.6.3"]]}})

--- a/src/geo/geohash.clj
+++ b/src/geo/geohash.clj
@@ -202,10 +202,9 @@
 
 (defn geohashes-intersecting
   ([shape desired-level] (geohashes-intersecting shape desired-level desired-level))
-  ([shape min-level max-level] (geohashes-intersecting shape min-level max-level (geohash "")))
-  ([shape min-level max-level _]
+  ([shape min-level max-level]
    (loop [matches #{}
-         queue (list (geohash ""))]
+          queue (list (geohash ""))]
      (if (empty? queue) matches
          (let [current (first queue)
                level (significant-bits current)]
@@ -214,12 +213,12 @@
              (if (= level max-level) (recur (conj matches current)
                                             (rest queue))
                  (if (>= level min-level)
-                     (recur (conj matches current)
-                            (into (rest queue)
-                                  (children current)))
-                     (recur matches
-                            (into (rest queue)
-                                  (children current)))))
+                   (recur (conj matches current)
+                          (into (rest queue)
+                                (children current)))
+                   (recur matches
+                          (into (rest queue)
+                                (children current)))))
              (recur matches (rest queue))))))))
 
 (defn geohashes-near

--- a/src/geo/geohash.clj
+++ b/src/geo/geohash.clj
@@ -4,8 +4,6 @@
 
   "
   (:use geo.spatial)
-  (:require [geo.jts :as jts]
-            [clojure.set])
   (:import (ch.hsr.geohash WGS84Point
                            GeoHash)
            (ch.hsr.geohash.util VincentyGeodesy)

--- a/src/geo/geohash.clj
+++ b/src/geo/geohash.clj
@@ -27,7 +27,7 @@
 
 (extend-protocol Shapelike
   GeoHash
-  (to-shape [geohash]
+  (to-shape [^GeoHash geohash]
             (let [box (.getBoundingBox geohash)]
               (.makeRectangle earth
                               (.getMinLon box)
@@ -187,7 +187,7 @@
   (min (least-upper-bound-index degrees-precision-lat-cache (height shape))
        (least-upper-bound-index degrees-precision-long-cache (height shape))))
 
-(defn bbox-geom [geohash]
+(defn bbox-geom [^GeoHash geohash]
   (let [bbox (.getBoundingBox geohash)
         rect (RectangleImpl. (.getMinLon bbox)
                              (.getMaxLon bbox)

--- a/src/geo/geohash.clj
+++ b/src/geo/geohash.clj
@@ -13,7 +13,6 @@
            (org.locationtech.spatial4j.distance DistanceUtils)
            (org.locationtech.spatial4j.context SpatialContextFactory)))
 
-(set! *warn-on-reflection* true)
 (defn geohash
   "Creates a geohash from a string, or at the given point with the given bit
   precision."

--- a/src/geo/geohash.clj
+++ b/src/geo/geohash.clj
@@ -9,7 +9,6 @@
            (ch.hsr.geohash.util VincentyGeodesy)
            (org.locationtech.spatial4j.shape.impl RectangleImpl)
            (org.locationtech.spatial4j.context.jts JtsSpatialContext)
-           (org.locationtech.spatial4j.io GeohashUtils)
            (org.locationtech.spatial4j.shape SpatialRelation)
            (org.locationtech.spatial4j.distance DistanceUtils)
            (org.locationtech.spatial4j.context SpatialContextFactory)))
@@ -200,45 +199,6 @@
 (defn geohashes-intersecting
   ([shape desired-level] (geohashes-intersecting shape desired-level desired-level))
   ([shape min-level max-level]
-   (loop [matches #{}
-          queue (list (geohash ""))]
-     (if (empty? queue)
-       matches
-       (let [current (first queue)
-             remaining (rest queue)
-             level (significant-bits current)]
-         (if (and (<= level max-level) (intersects? shape current))
-           (if (= level max-level)
-             (recur (conj matches current)
-                    remaining)
-             (if (>= level min-level)
-               (recur (conj matches current)
-                      (into remaining
-                            (subdivide current)))
-               (recur matches
-                      (into remaining
-                            (subdivide current)))))
-           (recur matches (rest queue))))))))
-
-(defn geohashes-intersecting-2
-  ([shape desired-level] (geohashes-intersecting shape desired-level desired-level))
-  ([shape min-level max-level]
-   (loop [matches (list)
-          queue (list (geohash ""))]
-     (if (empty? queue)
-       matches
-       (let [[current & remaining] queue
-             level (significant-bits current)
-             intersects (and (<= level max-level) (intersects? shape current))]
-         (cond
-           (not intersects) (recur matches remaining)
-           (= level max-level) (recur (conj matches current) remaining)
-           (>= level min-level) (recur (conj matches current) (into remaining (subdivide current)))
-           :else (recur matches (into remaining (subdivide current)))))))))
-
-(defn geohashes-intersecting-3
-  ([shape desired-level] (geohashes-intersecting shape desired-level desired-level))
-  ([shape min-level max-level]
    (loop [matches (list)
           queue (list (geohash ""))]
      (if (empty? queue)
@@ -251,48 +211,6 @@
            (= level max-level) (recur (conj matches current) (rest queue))
            (>= level min-level) (recur (conj matches current) (into (rest queue) (subdivide current)))
            :else (recur matches (into (rest queue) (subdivide current)))))))))
-
-(defn children [gh]
-   (->> gh string GeohashUtils/getSubGeohashes (map geohash)))
-
-(defn geohashes-intersecting-4
-  ([shape desired-level] (geohashes-intersecting shape desired-level desired-level))
-  ([shape min-level max-level]
-   (loop [matches #{}
-          queue (list (geohash ""))]
-     (if (empty? queue)
-       matches
-       (let [current (first queue)
-             remaining (rest queue)
-             level (significant-bits current)]
-         (if (and (<= level max-level) (intersects? shape current))
-           (if (= level max-level)
-             (recur (conj matches current)
-                    remaining)
-             (if (>= level min-level)
-               (recur (conj matches current)
-                      (into remaining
-                            (children current)))
-               (recur matches
-                      (into remaining
-                            (children current)))))
-           (recur matches (rest queue))))))))
-
-(defn geohashes-intersecting-5
-  ([shape desired-level] (geohashes-intersecting shape desired-level desired-level))
-  ([shape min-level max-level]
-   (loop [matches (list)
-          queue (list (geohash ""))]
-     (if (empty? queue)
-       matches
-       (let [current (first queue)
-             level (significant-bits current)
-             intersects (and (<= level max-level) (intersects? shape current))]
-         (cond
-           (not intersects) (recur matches (rest queue))
-           (= level max-level) (recur (conj matches current) (rest queue))
-           (>= level min-level) (recur (conj matches current) (into (rest queue) (children current)))
-           :else (recur matches (into (rest queue) (children current)))))))))
 
 (defn geohashes-near
   "Returns a list of geohashes of the given precision within radius meters of

--- a/src/geo/geohash.clj
+++ b/src/geo/geohash.clj
@@ -7,9 +7,9 @@
   (:import (ch.hsr.geohash WGS84Point
                            GeoHash)
            (ch.hsr.geohash.util VincentyGeodesy)
-           (com.spatial4j.core.shape SpatialRelation)
-           (com.spatial4j.core.distance DistanceUtils)
-           (com.spatial4j.core.context SpatialContextFactory)))
+           (org.locationtech.spatial4j.shape SpatialRelation)
+           (org.locationtech.spatial4j.distance DistanceUtils)
+           (org.locationtech.spatial4j.context SpatialContextFactory)))
 
 (defn geohash
   "Creates a geohash from a string, or at the given point with the given bit
@@ -81,7 +81,7 @@
                      +-----+
 
   If n is one, returns [origin].
-  
+
   This algorithm is undefined at the poles."
   [origin n]
   (assert (odd? n))

--- a/src/geo/geohash.clj
+++ b/src/geo/geohash.clj
@@ -9,7 +9,6 @@
            (ch.hsr.geohash.util VincentyGeodesy)
            (org.locationtech.spatial4j.shape.impl RectangleImpl)
            (org.locationtech.spatial4j.context.jts JtsSpatialContext)
-           (org.locationtech.spatial4j.io GeohashUtils)
            (org.locationtech.spatial4j.shape SpatialRelation)
            (org.locationtech.spatial4j.distance DistanceUtils)
            (org.locationtech.spatial4j.context SpatialContextFactory)))
@@ -188,9 +187,6 @@
   (min (least-upper-bound-index degrees-precision-lat-cache (height shape))
        (least-upper-bound-index degrees-precision-long-cache (height shape))))
 
-(defn children [gh]
-  (->> gh string GeohashUtils/getSubGeohashes (map geohash)))
-
 (defn bbox-geom [geohash]
   (let [bbox (.getBoundingBox geohash)
         rect (RectangleImpl. (.getMinLon bbox)
@@ -215,10 +211,10 @@
                  (if (>= level min-level)
                    (recur (conj matches current)
                           (into (rest queue)
-                                (children current)))
+                                (subdivide current)))
                    (recur matches
                           (into (rest queue)
-                                (children current)))))
+                                (subdivide current)))))
              (recur matches (rest queue))))))))
 
 (defn geohashes-near

--- a/src/geo/geohash.clj
+++ b/src/geo/geohash.clj
@@ -201,21 +201,23 @@
   ([shape min-level max-level]
    (loop [matches #{}
           queue (list (geohash ""))]
-     (if (empty? queue) matches
-         (let [current (first queue)
-               level (significant-bits current)]
-
-           (if (and (<= level max-level) (intersects? shape current))
-             (if (= level max-level) (recur (conj matches current)
-                                            (rest queue))
-                 (if (>= level min-level)
-                   (recur (conj matches current)
-                          (into (rest queue)
-                                (subdivide current)))
-                   (recur matches
-                          (into (rest queue)
-                                (subdivide current)))))
-             (recur matches (rest queue))))))))
+     (if (empty? queue)
+       matches
+       (let [current (first queue)
+             remaining (rest queue)
+             level (significant-bits current)]
+         (if (and (<= level max-level) (intersects? shape current))
+           (if (= level max-level)
+             (recur (conj matches current)
+                    remaining)
+             (if (>= level min-level)
+               (recur (conj matches current)
+                      (into remaining
+                            (subdivide current)))
+               (recur matches
+                      (into remaining
+                            (subdivide current)))))
+           (recur matches (rest queue))))))))
 
 (defn geohashes-near
   "Returns a list of geohashes of the given precision within radius meters of

--- a/src/geo/geohash.clj
+++ b/src/geo/geohash.clj
@@ -4,7 +4,8 @@
 
   "
   (:use geo.spatial)
-  (:require [geo.jts :as jts])
+  (:require [geo.jts :as jts]
+            [clojure.set])
   (:import (ch.hsr.geohash WGS84Point
                            GeoHash)
            (ch.hsr.geohash.util VincentyGeodesy)
@@ -41,6 +42,7 @@
 (defn eastern-neighbor [^GeoHash h] (.getEasternNeighbour h))
 (defn western-neighbor [^GeoHash h] (.getWesternNeighbour h))
 (defn southern-neighbor [^GeoHash h] (.getSouthernNeighbour h))
+(defn neighbors [^GeoHash h] (vec (.getAdjacent h)))
 
 (defn subdivide
   "Given a geohash, returns all geohashes inside it, of a given precision."

--- a/src/geo/io.clj
+++ b/src/geo/io.clj
@@ -1,0 +1,23 @@
+(ns geo.io
+  (:require [geo.spatial :as s]
+            [clojure.data])
+  (:import (com.vividsolutions.jts.io WKTReader WKTWriter WKBReader WKBWriter)
+           (org.wololo.jts2geojson GeoJSONReader GeoJSONWriter)))
+
+(def wkt-reader (WKTReader.))
+(def wkt-writer (WKTWriter.))
+
+(def wkb-reader (WKBReader.))
+(def wkb-writer (WKBWriter.))
+
+(def geojson-reader (GeoJSONReader.))
+(def geojson-writer (GeoJSONWriter.))
+
+(defn read-wkt [wkt] (.read wkt-reader wkt))
+(defn to-wkt [geom] (.write wkt-writer geom))
+
+(defn read-wkb [bytes] (.read wkb-reader bytes))
+(defn to-wkb [geom] (.write wkb-writer geom))
+
+(defn read-geojson [geojson] (.read geojson-reader geojson))
+(defn to-geojson [geom] (.toString (.write geojson-writer geom)))

--- a/src/geo/io.clj
+++ b/src/geo/io.clj
@@ -2,22 +2,23 @@
   (:require [geo.spatial :as s]
             [clojure.data])
   (:import (com.vividsolutions.jts.io WKTReader WKTWriter WKBReader WKBWriter)
+           (com.vividsolutions.jts.geom Geometry)
            (org.wololo.jts2geojson GeoJSONReader GeoJSONWriter)))
 
-(def wkt-reader (WKTReader.))
-(def wkt-writer (WKTWriter.))
+(def ^WKTReader wkt-reader (WKTReader.))
+(def ^WKTWriter wkt-writer (WKTWriter.))
 
-(def wkb-reader (WKBReader.))
-(def wkb-writer (WKBWriter.))
+(def ^WKBReader wkb-reader (WKBReader.))
+(def ^WKBWriter wkb-writer (WKBWriter.))
 
-(def geojson-reader (GeoJSONReader.))
-(def geojson-writer (GeoJSONWriter.))
+(def ^GeoJSONReader geojson-reader (GeoJSONReader.))
+(def ^GeoJSONWriter geojson-writer (GeoJSONWriter.))
 
-(defn read-wkt [wkt] (.read wkt-reader wkt))
-(defn to-wkt [geom] (.write wkt-writer geom))
+(defn read-wkt [^String wkt] (.read wkt-reader wkt))
+(defn to-wkt [^Geometry geom] (.write wkt-writer geom))
 
-(defn read-wkb [bytes] (.read wkb-reader bytes))
-(defn to-wkb [geom] (.write wkb-writer geom))
+(defn read-wkb [^bytes bytes] (.read wkb-reader bytes))
+(defn to-wkb [^Geometry geom] (.write wkb-writer geom))
 
-(defn read-geojson [geojson] (.read geojson-reader geojson))
-(defn to-geojson [geom] (.toString (.write geojson-writer geom)))
+(defn read-geojson [^String geojson] (.read geojson-reader geojson))
+(defn to-geojson [^Geometry geom] (.toString (.write geojson-writer geom)))

--- a/src/geo/spatial.clj
+++ b/src/geo/spatial.clj
@@ -41,16 +41,18 @@
 (def ^SpatialContext earth
   "The SpatialContext of the earth, as according to spatial4j."
   (SpatialContextFactory/makeSpatialContext
-    {"geo" "true" ; *any* string is true
-     "distCalculator" "vincentySphere"}
-    ; Optional classloader arg
-    nil))
+   {"geo" "true"
+    "datelineRule" "width180"
+    "spatialContextFactory" "org.locationtech.spatial4j.context.jts.JtsSpatialContextFactory"
+    "distCalculator" "vincentySphere"}
+   (.getClassLoader JtsSpatialContext)))
 
 (def ^ShapeFactory jts-earth
   "ShapeFactory for producing spatial4j Shapes from JTSGeometries based"
   (->> (.getClassLoader JtsSpatialContext)
        (SpatialContextFactory/makeSpatialContext
         {"geo" "true"
+         "datelineRule" "width180"
          "spatialContextFactory" "org.locationtech.spatial4j.context.jts.JtsSpatialContextFactory"
          "distCalculator" "vincentySphere"})
        (.getShapeFactory)))
@@ -94,7 +96,11 @@
 
   com.vividsolutions.jts.geom.Geometry
   (to-shape [this]
-    (.makeShape jts-earth this)))
+    (.makeShape jts-earth
+                (.clone this)
+                true ;; dateline180Check
+                false ;; allowMultiOverlap
+                )))
 
 (defprotocol Point
   (latitude [this])

--- a/src/geo/spatial.clj
+++ b/src/geo/spatial.clj
@@ -104,12 +104,10 @@
     ;; spatial4j / jts conversion issue: https://github.com/locationtech/spatial4j/issues/150
     (let [geom (if (crosses-dateline? this)
                  (.clone this)
-                 this)]
-      (.makeShape jts-earth
-                  geom
-                  true ;; dateline180Check
-                  false ;; allowMultiOverlap
-                  ))))
+                 this)
+          dateline-180-check? true
+          allow-multi-overlap? true]
+      (.makeShape jts-earth geom dateline-180-check? allow-multi-overlap?))))
 
 (defprotocol Point
   (latitude [this])

--- a/src/geo/spatial.clj
+++ b/src/geo/spatial.clj
@@ -25,6 +25,7 @@
                                              Shape
                                              ShapeFactory
                                              Rectangle)
+           (com.vividsolutions.jts.geom Geometry)
            (org.locationtech.spatial4j.shape.jts JtsGeometry)
            (org.locationtech.spatial4j.distance DistanceUtils
                                                 DistanceCalculator)
@@ -87,7 +88,7 @@
   "Earth's circumference around a meridian, in meters."
   (* 1000 40008))
 
-(defn crosses-dateline? [jts-geom]
+(defn crosses-dateline? [^Geometry jts-geom]
   (>= (.getWidth (.getEnvelopeInternal jts-geom))
       180))
 
@@ -98,7 +99,7 @@
   Shape
   (to-shape [this] this)
 
-  com.vividsolutions.jts.geom.Geometry
+  Geometry
   (to-shape [this]
     ;; Cloning geometries that cross dateline to workaround
     ;; spatial4j / jts conversion issue: https://github.com/locationtech/spatial4j/issues/150

--- a/test/geo/t_geohash.clj
+++ b/test/geo/t_geohash.clj
@@ -1,6 +1,7 @@
 (ns geo.t-geohash
   (:require [geo.spatial :as spatial]
             [geo.jts :as jts]
+            [geo.io :as gio]
             [criterium.core :as crit])
   (:use midje.sweet geo.geohash)
   (:import (ch.hsr.geohash GeoHash)
@@ -183,3 +184,13 @@
        (map string (neighbors (geohash "u4pruyd"))) => ["u4pruyf" "u4pruyg" "u4pruye"
                                                         "u4pruy7" "u4pruy6" "u4pruy3"
                                                         "u4pruy9" "u4pruyc"])
+(comment
+  "intersecting-geohashes benchmarking"
+  (let [sample-wkt "POLYGON((-107.814331054688 33.9746840624585,-107.63786315918 34.2560813847164,-107.405776977539 33.9991657910092,-107.814331054688 33.9746840624585))"
+        sample-wkt-2 "POLYGON((-117.904586791992 34.9164815742019,-117.887420654297 34.9242230169058,-117.89201259613 34.9413219789948,-117.885317802429 34.9604925010402,-117.870254516602 34.9942850112354,-117.788200378418 34.9906286382738,-117.746658325195 34.9624972324491,-117.837295532227 34.9264749358464,-117.861843109131 34.9218302853154,-117.852573394775 34.918170678527,-117.869567871094 34.9083170799602,-117.850341796875 34.9004333495724,-117.862014770508 34.8802982472034,-117.86598443985 34.8796645450209,-117.87469625473 34.886265369791,-117.884159088135 34.8933936650348,-117.885360717773 34.9005741371092,-117.907333374023 34.8908592309128,-117.915058135986 34.8995886192834,-117.904586791992 34.9069093264736,-117.912397384644 34.9043049188956,-117.916774749756 34.9074724307645,-117.904586791992 34.9164815742019))"
+        sample-geom (gio/read-wkt sample-wkt)
+        sample-geom-2 (gio/read-wkt sample-wkt-2)
+        big-geom (jts/polygon-wkt [[70 30, 70 31, 71, 31, 71 30, 70 30]])])
+  (crit/with-progress-reporting (crit/bench (geohashes-intersecting sample-geom 35)))
+  (crit/with-progress-reporting (crit/bench (geohashes-intersecting sample-geom-2 35)))
+  (crit/with-progress-reporting (crit/bench (geohashes-intersecting big-geom 35))))

--- a/test/geo/t_geohash.clj
+++ b/test/geo/t_geohash.clj
@@ -1,10 +1,14 @@
 (ns geo.t-geohash
+  (:require [geo.spatial :as spatial])
   (:use midje.sweet
         [geo.jts :only [multi-polygon-wkt]]
         [geo.spatial :only [geohash-point area]]
         geo.geohash)
   (:import (ch.hsr.geohash GeoHash)
-           (com.spatial4j.core.context SpatialContext)))
+           (org.locationtech.spatial4j.context SpatialContext)
+           (com.vividsolutions.jts.geom PrecisionModel
+                                        Envelope
+                                        GeometryFactory)))
 
 (facts "geohash"
        (fact (geohash 50 20 64) => (partial instance? GeoHash))
@@ -70,7 +74,7 @@
          (fact "eighth earth"
                (area (geohash 45 0 3)) => (roughly (/ a 8)))
          ; As we start digging down, the skew becomes more pronounced.
-         (fact "1/256ths" (area (geohash 45 0 8)) 
+         (fact "1/256ths" (area (geohash 45 0 8))
                => (roughly (/ a (Math/pow 2 8)) (/ a (Math/pow 2 15))))
          (fact "1/65536ths" (area (geohash 45 0 16))
                => (roughly (/ a (Math/pow 2 16)) (/ a (Math/pow 2 19))))
@@ -135,7 +139,7 @@
                        "pwyptwze" "pwyptybp" "pwyptybr" "pwyptybx" "pwyptybz"
                        "pwyptycp" "pwyptycr"] :in-any-order))
        (fact "10 meter radius with 45 bits precision"
-             (map string 
+             (map string
                   (geohashes-near (geohash-point 35.971411 -121.453086) 10 45))
              => (just ["9q3ssk2s9" "9q3ssk2sf" "9q3ssk2sd" "9q3ssk2s6"
                        "9q3ssk2s3" "9q3ssk2s2" "9q3ssk2s8" "9q3ssk2sb"

--- a/test/geo/t_geohash.clj
+++ b/test/geo/t_geohash.clj
@@ -183,19 +183,3 @@
        (map string (neighbors (geohash "u4pruyd"))) => ["u4pruyf" "u4pruyg" "u4pruye"
                                                         "u4pruy7" "u4pruy6" "u4pruy3"
                                                         "u4pruy9" "u4pruyc"])
-
-(facts "Geohash benchmarks"
-       (let [wkt [[70 30, 70 31, 71, 31, 71 30, 70 30]]
-             geom (jts/polygon-wkt wkt)
-             times 20]
-         (println "*** 1")
-         (crit/with-progress-reporting (crit/bench (geohashes-intersecting geom 25)))
-         (println "*** 2")
-         (crit/with-progress-reporting (crit/bench (geohashes-intersecting-2 geom 25)))
-         (println "*** 3")
-         (crit/with-progress-reporting (crit/bench (geohashes-intersecting-3 geom 25)))
-         (println "*** 4")
-         (crit/with-progress-reporting (crit/bench (geohashes-intersecting-4 geom 25)))
-         (println "*** 5")
-         (crit/with-progress-reporting (crit/bench (geohashes-intersecting-5 geom 25)))
-         ))

--- a/test/geo/t_geohash.clj
+++ b/test/geo/t_geohash.clj
@@ -1,9 +1,7 @@
 (ns geo.t-geohash
-  (:require [geo.spatial :as spatial])
-  (:use midje.sweet
-        [geo.jts :only [multi-polygon-wkt]]
-        [geo.spatial :only [geohash-point area]]
-        geo.geohash)
+  (:require [geo.spatial :as spatial]
+            [geo.jts :as jts])
+  (:use midje.sweet geo.geohash)
   (:import (ch.hsr.geohash GeoHash)
            (org.locationtech.spatial4j.context SpatialContext)
            (com.vividsolutions.jts.geom PrecisionModel
@@ -14,7 +12,7 @@
        (fact (geohash 50 20 64) => (partial instance? GeoHash))
        (fact "from string"
              (geohash-center (geohash "u4pruydqqvj"))
-             => (geohash-point 57.64911063015461 10.407439693808556)))
+             => (spatial/geohash-point 57.64911063015461 10.407439693808556)))
 
 (facts "subdivide"
        (fact (map #(.longValue %) (subdivide (geohash "")))
@@ -68,31 +66,31 @@
 (facts "geohash-area"
        (let [a 5.101e14] ; Earth's surface
          (fact "whole earth"
-               (area (geohash 45 0 0)) => (roughly a))
+               (spatial/area (geohash 45 0 0)) => (roughly a))
          (fact "half earth"
-               (area (geohash 45 0 1)) => (roughly (/ a 2)))
+               (spatial/area (geohash 45 0 1)) => (roughly (/ a 2)))
          (fact "eighth earth"
-               (area (geohash 45 0 3)) => (roughly (/ a 8)))
+               (spatial/area (geohash 45 0 3)) => (roughly (/ a 8)))
          ; As we start digging down, the skew becomes more pronounced.
-         (fact "1/256ths" (area (geohash 45 0 8))
+         (fact "1/256ths" (spatial/area (geohash 45 0 8))
                => (roughly (/ a (Math/pow 2 8)) (/ a (Math/pow 2 15))))
-         (fact "1/65536ths" (area (geohash 45 0 16))
+         (fact "1/65536ths" (spatial/area (geohash 45 0 16))
                => (roughly (/ a (Math/pow 2 16)) (/ a (Math/pow 2 19))))
-         (fact "2^-30ths" (area (geohash 45 0 30))
+         (fact "2^-30ths" (spatial/area (geohash 45 0 30))
                => (roughly (/ a (Math/pow 2 30)) (/ a (Math/pow 2 33))))
-         (fact "2^-50ths" (area (geohash 45 0 30))
+         (fact "2^-50ths" (spatial/area (geohash 45 0 30))
                => (roughly (/ a (Math/pow 2 50)) (/ a (Math/pow 2 29))))
 
          ; 40 bits of precision gets you a 700 square meter block at the equator
          (fact "40 bits at the equator"
-               (area (geohash 0 0 40)) => (roughly 728.6959))
+               (spatial/area (geohash 0 0 40)) => (roughly 728.6959))
          (fact "40 bits at 45 degrees"
-               (area (geohash 45 0 40)) => (roughly 515.265))
+               (spatial/area (geohash 45 0 40)) => (roughly 515.265))
          (fact "40 bits at 60 degrees"
-               (area (geohash 60 0 40)) => (roughly 364.34))
+               (spatial/area (geohash 60 0 40)) => (roughly 364.34))
          ; But only a narrow slice at the pole
          (fact "40 bits at the pole"
-               (area (geohash 90 0 40)) => (roughly 0.001091)))
+               (spatial/area (geohash 90 0 40)) => (roughly 0.001091)))
 
        (facts "geohash-precision-max-error"
               (fact "20 bits" (geohash-max-error 20) => (roughly 43696.))
@@ -107,19 +105,19 @@
 
 (facts "geohashes-near"
        (fact "10 meter radius around 1,1 with 35 bits precision"
-             (map string (geohashes-near (geohash-point 1 1) 10 35))
+             (map string (geohashes-near (spatial/geohash-point 1 1) 10 35))
              => ["s00twy0"])
        (fact "100 meter radius with 35 bits precision"
              (map string
-                  (geohashes-near (geohash-point 37.613834 -119.088062) 100 35))
+                  (geohashes-near (spatial/geohash-point 37.613834 -119.088062) 100 35))
              => (just ["9qemfp6" "9qemfpe" "9qemfp7" "9qemfp5" "9qemfp4" "9qemfp3"
                        "9qemfpd"] :in-any-order))
        (fact "10 meter radius around 1,1 with 40 bits precision"
-             (map string (geohashes-near (geohash-point 1 1) 10 40))
+             (map string (geohashes-near (spatial/geohash-point 1 1) 10 40))
              => (just ["s00twy01" "s00twy00"] :in-any-order))
        (fact "100 meter radius with 40 bits precision"
              (map string
-                  (geohashes-near (geohash-point -50.675351 166.191226) 100 40))
+                  (geohashes-near (spatial/geohash-point -50.675351 166.191226) 100 40))
              => (just ["pwyptybf" "pwyptyc5" "pwyptyc4" "pwyptyc1" "pwyptybc"
                        "pwyptyb9" "pwyptybd" "pwyptybe" "pwyptybg" "pwyptyck"
                        "pwyptyc7" "pwyptyc6" "pwyptyc3" "pwyptyc2" "pwyptyc0"
@@ -140,7 +138,7 @@
                        "pwyptycp" "pwyptycr"] :in-any-order))
        (fact "10 meter radius with 45 bits precision"
              (map string
-                  (geohashes-near (geohash-point 35.971411 -121.453086) 10 45))
+                  (geohashes-near (spatial/geohash-point 35.971411 -121.453086) 10 45))
              => (just ["9q3ssk2s9" "9q3ssk2sf" "9q3ssk2sd" "9q3ssk2s6"
                        "9q3ssk2s3" "9q3ssk2s2" "9q3ssk2s8" "9q3ssk2sb"
                        "9q3ssk2sc" "9q3ssk2t5" "9q3ssk2sg" "9q3ssk2se"
@@ -156,7 +154,22 @@
        (fact (shape->precision (geohash 45 45 2)) => 1)
        (fact (shape->precision (geohash 45 45 64)) => 63))
 
-(facts "alaska"
-       (let [evil (multi-polygon-wkt [[[179 0, 179 1, -179 1, -179 0, 179 0]]])]
-         (fact (map string (geohashes-intersecting evil 15))
+(facts "Geohashes covering a shape"
+       (let [wkt [[70 30, 70 31, 71, 31, 71 30, 70 30]]]
+         (time (-> wkt jts/polygon-wkt (covering-geohashes 25)))
+         (time (map string (-> wkt jts/polygon-wkt (geohashes-intersecting 25))))
+         (fact (-> wkt jts/polygon-wkt (covering-geohashes 15)) => #{"tt6" "tt9" "tt3" "ttd"})))
+
+(facts "Geohashes for dateline-crossing polygons"
+       (let [polygon (jts/polygon-wkt [[179 0, 179 1, -179 1, -179 0, 179 0]])]
+         (fact (covering-geohashes polygon 15)
+               => (just ["xbp" "800" "2pb" "rzz"] :in-any-order))
+         (fact (map string (geohashes-intersecting polygon 15))
                => (just ["xbp" "800" "2pb" "rzz"] :in-any-order))))
+
+(facts "Intersecting Geohashes for geometry crossing origin (equator and prime meridian)"
+       (let [factory (GeometryFactory. (PrecisionModel.) 4326)
+             envelope (Envelope. -2.0 2.0 -2.0 2.0)
+             geom (.toGeometry factory envelope)]
+         (fact (map string (geohashes-intersecting geom 10))
+               => (just ["s0" "kp" "7z" "eb"] :in-any-order))))

--- a/test/geo/t_geohash.clj
+++ b/test/geo/t_geohash.clj
@@ -1,6 +1,7 @@
 (ns geo.t-geohash
   (:require [geo.spatial :as spatial]
-            [geo.jts :as jts])
+            [geo.jts :as jts]
+            [criterium.core :as crit])
   (:use midje.sweet geo.geohash)
   (:import (ch.hsr.geohash GeoHash)
            (org.locationtech.spatial4j.context SpatialContext)
@@ -182,3 +183,19 @@
        (map string (neighbors (geohash "u4pruyd"))) => ["u4pruyf" "u4pruyg" "u4pruye"
                                                         "u4pruy7" "u4pruy6" "u4pruy3"
                                                         "u4pruy9" "u4pruyc"])
+
+(facts "Geohash benchmarks"
+       (let [wkt [[70 30, 70 31, 71, 31, 71 30, 70 30]]
+             geom (jts/polygon-wkt wkt)
+             times 20]
+         (println "*** 1")
+         (crit/with-progress-reporting (crit/bench (geohashes-intersecting geom 25)))
+         (println "*** 2")
+         (crit/with-progress-reporting (crit/bench (geohashes-intersecting-2 geom 25)))
+         (println "*** 3")
+         (crit/with-progress-reporting (crit/bench (geohashes-intersecting-3 geom 25)))
+         (println "*** 4")
+         (crit/with-progress-reporting (crit/bench (geohashes-intersecting-4 geom 25)))
+         (println "*** 5")
+         (crit/with-progress-reporting (crit/bench (geohashes-intersecting-5 geom 25)))
+         ))

--- a/test/geo/t_geohash.clj
+++ b/test/geo/t_geohash.clj
@@ -155,15 +155,13 @@
        (fact (shape->precision (geohash 45 45 64)) => 63))
 
 (facts "Geohashes covering a shape"
-       (let [wkt [[70 30, 70 31, 71, 31, 71 30, 70 30]]]
-         (time (-> wkt jts/polygon-wkt (covering-geohashes 25)))
-         (time (map string (-> wkt jts/polygon-wkt (geohashes-intersecting 25))))
-         (fact (-> wkt jts/polygon-wkt (covering-geohashes 15)) => #{"tt6" "tt9" "tt3" "ttd"})))
+       (let [wkt [[70 30, 70 31, 71, 31, 71 30, 70 30]]
+             geom (jts/polygon-wkt wkt)]
+         (fact (map string (geohashes-intersecting geom 15)) => (just ["tt6" "tt9" "tt3" "ttd"]
+                                                                      :in-any-order))))
 
 (facts "Geohashes for dateline-crossing polygons"
        (let [polygon (jts/polygon-wkt [[179 0, 179 1, -179 1, -179 0, 179 0]])]
-         (fact (covering-geohashes polygon 15)
-               => (just ["xbp" "800" "2pb" "rzz"] :in-any-order))
          (fact (map string (geohashes-intersecting polygon 15))
                => (just ["xbp" "800" "2pb" "rzz"] :in-any-order))))
 
@@ -173,6 +171,12 @@
              geom (.toGeometry factory envelope)]
          (fact (map string (geohashes-intersecting geom 10))
                => (just ["s0" "kp" "7z" "eb"] :in-any-order))))
+
+(facts "Intersecting geohashes for multipolygon"
+       (let [geom (jts/multi-polygon-wkt [[[70 30, 70 31, 71, 31, 71 30, 70 30]]
+                                          [[-50 20, -50 21, -51, 21, -51 20, -50 20]]])]
+         (fact (map string (geohashes-intersecting geom 15))
+               => (just ["dgs" "tt6" "dge" "ttd" "tt3" "tt9"] :in-any-order))))
 
 (facts "Neighbors"
        (map string (neighbors (geohash "u4pruyd"))) => ["u4pruyf" "u4pruyg" "u4pruye"

--- a/test/geo/t_geohash.clj
+++ b/test/geo/t_geohash.clj
@@ -173,3 +173,8 @@
              geom (.toGeometry factory envelope)]
          (fact (map string (geohashes-intersecting geom 10))
                => (just ["s0" "kp" "7z" "eb"] :in-any-order))))
+
+(facts "Neighbors"
+       (map string (neighbors (geohash "u4pruyd"))) => ["u4pruyf" "u4pruyg" "u4pruye"
+                                                        "u4pruy7" "u4pruy6" "u4pruy3"
+                                                        "u4pruy9" "u4pruyc"])

--- a/test/geo/t_io.clj
+++ b/test/geo/t_io.clj
@@ -1,0 +1,33 @@
+(ns geo.t-io
+  (:require [geo.io :as sut]
+            [midje.sweet :as midje :refer [fact facts]]))
+
+(def wkt "POLYGON ((-70.0024 30.0019, -70.0024 30.0016, -70.0017 30.0016, -70.0017 30.0019, -70.0024 30.0019))")
+(def wkt-2 "POLYGON ((-118.41632050954 34.0569111034308,-118.416338488265 34.0568986639481,-118.416492289093 34.0567922421742,-118.416530323474 34.0567659511355,-118.418142315196 34.0556504823845,-118.418150052351 34.0556594411781,-118.418689703423 34.0562853532086,-118.418415962306 34.0564736252562,-118.418418218819 34.0564759256614,-118.418378572273 34.0565031846417,-118.418376282883 34.0565009118285,-118.418233752614 34.0565989279524,-118.418236937922 34.0566021044676,-118.418196205493 34.0566301090773,-118.4181930532 34.0566269324467,-118.418073292223 34.0567096187712,-118.417930201783 34.0568079936995,-118.417773815715 34.0566504764553,-118.41769386392 34.0567054359181,-118.417612270018 34.0566232540736,-118.416840191548 34.0571544513339,-118.416817318266 34.0571701863547,-118.41678665332 34.0571912877453,-118.416674690686 34.0572683160349,-118.41632050954 34.0569111034308))")
+(def geojson "{\"type\":\"Polygon\",\"coordinates\":[[[-70.0024,30.0019],[-70.0024,30.0016],[-70.0017,30.0016],[-70.0017,30.0019],[-70.0024,30.0019]]]}")
+
+(def coords [[-70.0024 30.0019]
+             [-70.0024 30.0016]
+             [-70.0017 30.0016]
+             [-70.0017 30.0019]
+             [-70.0024 30.0019]])
+
+(fact "reads and writes wkt"
+      (type (sut/read-wkt wkt)) => com.vividsolutions.jts.geom.Polygon
+      (.getNumPoints (sut/read-wkt wkt)) => 5
+      (map (fn [c] [(.x c) (.y c)]) (.getCoordinates (sut/read-wkt wkt))) => coords
+      (-> wkt sut/read-wkt sut/to-wkt) => wkt)
+
+(fact "reads and writes wkb"
+      (let [geom (sut/read-wkt wkt)
+            wkb (sut/to-wkb geom)]
+        (count wkb) => 93
+        (.getNumPoints (sut/read-wkb wkb)) => 5
+        (map (fn [c] [(.x c) (.y c)]) (.getCoordinates (sut/read-wkt wkt))) => coords
+        (-> wkt sut/read-wkt sut/to-wkb sut/read-wkb sut/to-wkt) => wkt))
+
+(fact "reads and writes geojson"
+      (type (sut/read-geojson geojson)) => com.vividsolutions.jts.geom.Polygon
+      (.getNumPoints (sut/read-geojson geojson)) => 5
+      (map (fn [c] [(.x c) (.y c)]) (.getCoordinates (sut/read-geojson geojson))) => coords
+      (-> geojson sut/read-geojson sut/to-geojson) => geojson)

--- a/test/geo/t_spatial.clj
+++ b/test/geo/t_spatial.clj
@@ -125,11 +125,12 @@
          (fact (-> [poly-wkt] jts/multi-polygon-wkt s/width) => 2.0)
          (fact (-> poly-wkt jts/polygon-wkt s/bounding-box s/area) => (roughly 2.4727e10))))
 
-(facts "BUG: Multiple to-shape calls breaks dateline handling without cloning"
+(facts "Dateline-crossing geom handled properly with multiple to-shape calls"
+       ;; Protecting against a previous bug
+       ;; https://github.com/locationtech/spatial4j/issues/150
        (let [polygon (jts/polygon-wkt [[179 0 179 1 -179 1 -179 0 179 0]])]
          (fact (s/width polygon) => 2.0)
-         (fact (s/width polygon) => 2.0)
-         (fact (s/width bbox-1) => (s/width bbox-2))))
+         (fact (s/width polygon) => 2.0)))
 
 (facts "centroid"
        (fact (-> [[0 0, 10 0, 10 10, 0 10, 0 0]]

--- a/test/geo/t_spatial.clj
+++ b/test/geo/t_spatial.clj
@@ -1,76 +1,75 @@
 (ns geo.t-spatial
-  (:use midje.sweet
-        geo.spatial
-        [geo.jts :only [multi-polygon-wkt]])
-  (:require [geo.jts :as jts])
+  (:use midje.sweet)
+  (:require [geo.jts :as jts]
+            [geo.spatial :as s])
   (:import (org.locationtech.spatial4j.context SpatialContext)))
 
 (facts "earth"
-       (fact earth => (partial instance? SpatialContext)))
+       (fact s/earth => (partial instance? SpatialContext)))
 
 (facts "earth-radius"
        (fact "accurate at equator"
-             (earth-radius (geohash-point 0 0))
-             => (roughly earth-equatorial-radius 1/10000))
+             (s/earth-radius (s/geohash-point 0 0))
+             => (roughly s/earth-equatorial-radius 1/10000))
        (fact "accurate at pole"
-             (earth-radius (geohash-point 90 0))
-             => (roughly earth-polar-radius 1/10000))
+             (s/earth-radius (s/geohash-point 90 0))
+             => (roughly s/earth-polar-radius 1/10000))
        ; A particularly special point in France which we know the radius for
        (fact "accurate in France"
-             (earth-radius (geohash-point 48.46791 0))
+             (s/earth-radius (s/geohash-point 48.46791 0))
              => (roughly 6366197 10)))
 
 (facts "degrees->radians"
-       (fact (degrees->radians 0) => 0.0)
-       (fact (degrees->radians 180) => Math/PI)
-       (fact (degrees->radians 360) => (* 2 Math/PI)))
+       (fact (s/degrees->radians 0) => 0.0)
+       (fact (s/degrees->radians 180) => Math/PI)
+       (fact (s/degrees->radians 360) => (* 2 Math/PI)))
 
 (facts "radians->degrees"
-       (fact (radians->degrees 0) => 0.0)
-       (fact (radians->degrees Math/PI) => 180.0)
-       (fact (radians->degrees (* 2 Math/PI)) => 360.0))
+       (fact (s/radians->degrees 0) => 0.0)
+       (fact (s/radians->degrees Math/PI) => 180.0)
+       (fact (s/radians->degrees (* 2 Math/PI)) => 360.0))
 
 (facts "square-degrees->steradians"
-       (fact (square-degrees->steradians (square (/ 180 Math/PI)))
+       (fact (s/square-degrees->steradians (s/square (/ 180 Math/PI)))
              => (roughly 1 0.00001)))
 
 (facts "distance->radians"
-       (fact (distance->radians 0) => 0.0)
-       (fact (distance->radians earth-mean-circumference)
+       (fact (s/distance->radians 0) => 0.0)
+       (fact (s/distance->radians s/earth-mean-circumference)
              => (roughly (* 2 Math/PI))))
 
 (facts "radians->distance"
-       (fact (radians->distance 0 0.0))
-       (fact (radians->distance (* 2 Math/PI))
-             => (roughly earth-mean-circumference)))
+       (fact (s/radians->distance 0 0.0))
+       (fact (s/radians->distance (* 2 Math/PI))
+             => (roughly s/earth-mean-circumference)))
 
 (facts "interchangeable points"
-       (let [flip-spatial (comp to-spatial4j-point to-geohash-point)
-             flip-geohash (comp to-geohash-point to-spatial4j-point)
-             g1 (geohash-point 0 0)
-             g2 (geohash-point 12.456 -98.765)
-             s1 (spatial4j-point 0 0)   
-             s2 (spatial4j-point 12.456 -98.765)]
+       (let [flip-spatial (comp s/to-spatial4j-point s/to-geohash-point)
+             flip-geohash (comp s/to-geohash-point s/to-spatial4j-point)
+             g1 (s/geohash-point 0 0)
+             g2 (s/geohash-point 12.456 -98.765)
+             s1 (s/spatial4j-point 0 0)
+             s2 (s/spatial4j-point 12.456 -98.765)]
          ; Identity conversions
-         (fact (to-geohash-point g2) g2)
-         (fact (to-spatial4j-point g2) s2)
-         
+         (fact (s/to-geohash-point g2) g2)
+         (fact (s/to-spatial4j-point g2) s2)
+
          ; Direct conversions
-         (fact (to-spatial4j-point s2) s2)
-         (fact (to-geohash-point s2) g2)
+         (fact (s/to-spatial4j-point s2) s2)
+         (fact (s/to-geohash-point s2) g2)
 
          ; Two-way conversions
-         (fact (flip-geohash g1) => g1) 
+         (fact (flip-geohash g1) => g1)
          (fact (flip-geohash g2) => g2)
          (fact (flip-spatial s1) => s1)
          (fact (flip-spatial s2) => s2)))
 
 ; Have some airports
-(let [lhr (spatial4j-point 51.477500 -0.461388)
-      syd (spatial4j-point -33.946110 151.177222)
-      lax (spatial4j-point 33.942495 -118.408067)
-      sfo (spatial4j-point 37.619105 -122.375236)
-      oak (spatial4j-point 37.721306 -122.220721)
+(let [lhr (s/spatial4j-point 51.477500 -0.461388)
+      syd (s/spatial4j-point -33.946110 151.177222)
+      lax (s/spatial4j-point 33.942495 -118.408067)
+      sfo (s/spatial4j-point 37.619105 -122.375236)
+      oak (s/spatial4j-point 37.721306 -122.220721)
       ; and some distances between them, in meters
       lhr-syd 17015628
       syd-lax 12050690
@@ -80,51 +79,57 @@
   (facts "distance in meters"
          ; This breaks VincentyGeodesy from the geohash library; there's a
          ; singularity at the poles.
-         (future-fact (distance (geohash-point 89.999, 0)
+         (future-fact (s/distance (geohash-point 89.999, 0)
                          (geohash-point 90.0, 0))
                => 1.234567)
-         (fact (distance lhr syd) => (roughly lhr-syd))
-         (fact (distance syd lax) => (roughly syd-lax))
-         (fact (distance lax lhr) => (roughly lax-lhr))
-         (fact (distance (geohash-point sfo)
-                         (geohash-point oak)) => (roughly sfo-oak)))
+         (fact (s/distance lhr syd) => (roughly lhr-syd))
+         (fact (s/distance syd lax) => (roughly syd-lax))
+         (fact (s/distance lax lhr) => (roughly lax-lhr))
+         (fact (s/distance (s/geohash-point sfo)
+                         (s/geohash-point oak)) => (roughly sfo-oak)))
 
   (facts "intersections"
          (fact "A circle around a point intersects that point."
-               (intersects? (circle lhr 10) lhr) => truthy)
+               (s/intersects? (s/circle lhr 10) lhr) => truthy)
          (fact "A circle around Sydney to London has an error of ~ 5 KM"
                ; This is a pretty darn big circle; covers more than half the
                ; globe.
-               (intersects? syd (circle lhr (+ 4500 (distance lhr syd))))
+               (s/intersects? syd (s/circle lhr (+ 4500 (s/distance lhr syd))))
                => falsey
-               (intersects? syd (circle lhr (+ 5000 (distance lhr syd))))
+               (s/intersects? syd (s/circle lhr (+ 5000 (s/distance lhr syd))))
                => truthy)
          (fact "A circle around SFO to OAK has an error of roughly 13 meters."
-               (intersects? sfo (circle oak (- (distance sfo oak) 12)))
+               (s/intersects? sfo (s/circle oak (- (s/distance sfo oak) 12)))
                => truthy
-               (intersects? sfo (circle oak (- (distance sfo oak) 14)))
+               (s/intersects? sfo (s/circle oak (- (s/distance sfo oak) 14)))
                => falsey))
 
   (facts "relationships"
          (fact "relate returns keywords"
-               (relate (circle oak 10) (circle oak 10))
+               (s/relate (s/circle oak 10) (s/circle oak 10))
                => :contains)))
 
 (facts "JTS multi-polygons"
-       (let [a (multi-polygon-wkt [[[0 0, 2 0, 2 2, 0 0]]])
-             b (multi-polygon-wkt [[[0 0, 1 0, 0 1, 0 0]]])
-             c (multi-polygon-wkt [[[-1 -1, -2 -2, -1 -2, -1 -1]]])]
-         (fact (intersects? a b) => true)
-         (fact (intersects? a c) => false)
-         (fact (intersects? b c) => false)))
+       (let [a (jts/multi-polygon-wkt [[[0 0, 2 0, 2 2, 0 0]]])
+             b (jts/multi-polygon-wkt [[[0 0, 1 0, 0 1, 0 0]]])
+             c (jts/multi-polygon-wkt [[[-1 -1, -2 -2, -1 -2, -1 -1]]])]
+         (fact (s/intersects? a b) => true)
+         (fact (s/intersects? a c) => false)
+         (fact (s/intersects? b c) => false)))
 
-(facts "Alaska"
-       (let [evil (multi-polygon-wkt [[[179 0, 179 1, -179 1, -179 0, 179 0]]])]
-         (fact (height evil) => 1.0)
-         (fact (width evil) => 2.0)
-         (fact (area (bounding-box evil)) => (roughly 2.4727e10))
-         (fact (center (bounding-box evil)) => (point 0.5 180.0))
-         (fact (center evil) => (point 0.5 180.0))))
+(facts "Dateline Polygons"
+       (let [poly-wkt [[179 0 179 1 -179 1 -179 0 179 0]]]
+         (fact (-> poly-wkt jts/polygon-wkt s/height) => 1.0)
+         (fact (-> poly-wkt jts/polygon-wkt s/width) => 2.0)
+         (fact (-> poly-wkt jts/polygon-wkt s/bounding-box s/width) => 2.0)
+         (fact (-> [poly-wkt] jts/multi-polygon-wkt s/width) => 2.0)
+         (fact (-> poly-wkt jts/polygon-wkt s/bounding-box s/area) => (roughly 2.4727e10))))
+
+(facts "BUG: Multiple to-shape calls breaks dateline handling without cloning"
+       (let [polygon (jts/polygon-wkt [[179 0 179 1 -179 1 -179 0 179 0]])]
+         (fact (s/width polygon) => 2.0)
+         (fact (s/width polygon) => 2.0)
+         (fact (s/width bbox-1) => (s/width bbox-2))))
 
 (facts "centroid"
        (fact (-> [[0 0, 10 0, 10 10, 0 10, 0 0]]
@@ -132,5 +137,5 @@
                   ; Maybe someday, try holes?
                   ; [1 1, 5 1,  5 9,   1 9,  1 1]]
                  jts/polygon-wkt
-                 center)
-             => (spatial4j-point 5 5)))
+                 s/center)
+             => (s/spatial4j-point 5 5)))

--- a/test/geo/t_spatial.clj
+++ b/test/geo/t_spatial.clj
@@ -3,7 +3,7 @@
         geo.spatial
         [geo.jts :only [multi-polygon-wkt]])
   (:require [geo.jts :as jts])
-  (:import (com.spatial4j.core.context SpatialContext)))
+  (:import (org.locationtech.spatial4j.context SpatialContext)))
 
 (facts "earth"
        (fact earth => (partial instance? SpatialContext)))
@@ -134,5 +134,3 @@
                  jts/polygon-wkt
                  center)
              => (spatial4j-point 5 5)))
-
-                  


### PR DESCRIPTION
I'm trying to resuscitate this library a bit so I can start using it more for various projects.

One of the first things I wanted to tackle was getting our versions of JTS and Spatial4J updated since they're several years old at this point.

During the process of these updates I ran into a few corner-cases around handling geometries that cross the international dateline and had to resolve those.

I think I have it working now at least as well as it was before, and I was able to fix a couple geohash edge cases along the way by simplifying our intersecting-geohashes implementation a bit as well.

Also took the opportunity to add a simple IO namespace with some read/write utility functions.