### PR TITLE
Bump midje to remove warnings when running tests

### DIFF
--- a/project.clj
+++ b/project.clj
@@ -14,9 +14,9 @@
    [org.locationtech.jts.io/jts-io-common "1.15.0"]
    [org.noggit/noggit "0.8"]]
   :codox {:themes [:rdash]}
-  :profiles {:dev {:plugins [[lein-midje "3.1.1"]
+  :profiles {:dev {:plugins [[lein-midje "3.2.1"]
                              [lein-codox "0.10.3"]]
-                   :dependencies [[org.clojure/clojure "1.8.0"]
+                   :dependencies [[org.clojure/clojure "1.9.0"]
                                   [codox-theme-rdash "0.1.2"]
                                   [criterium "0.4.4"]
-                                  [midje "1.6.3"]]}})
+                                  [midje "1.9.1"]]}})


### PR DESCRIPTION
Update the midje dependency to remove the warnings currently displayed when running tests:

```
WARNING: cat already refers to: #'clojure.core/cat in namespace: net.cgrand.parsley.fold, being replaced by: #'net.cgrand.parsley.fold/cat
WARNING: update already refers to: #'clojure.core/update in namespace: utilize.map, being replaced by: #'utilize.map/update
WARNING: update already refers to: #'clojure.core/update in namespace: clojure.math.combinatorics, being replaced by: #'clojure.math.combinatorics/update
```