### PR TITLE
use wgs84 GeometryFactory for io namespace readers

### DIFF
--- a/src/geo/io.clj
+++ b/src/geo/io.clj
@@ -1,7 +1,7 @@
 (ns geo.io
   "Helper functions for converting JTS geometries to and from various
    geospatial IO formats (geojson, wkt, wkb)."
-  (:require [geo.jts :refer [gf-wgs84]]
+  (:require [geo.jts :refer [gf-wgs84] :as jts]
             [clojure.data])
   (:import (org.locationtech.jts.io WKTReader WKTWriter WKBReader WKBWriter)
            (org.locationtech.jts.geom Geometry)
@@ -19,18 +19,28 @@
 
 (.setEncodeCRS geojson-writer false)
 
-(defn read-wkt [^String wkt] (.read wkt-reader wkt))
+(defn read-wkt
+  "Read a WKT string and convert to a Geometry.
+   Can optionally pass in SRID. Defaults to WGS84"
+  ([^String wkt] (.read wkt-reader wkt))
+  ([^String wkt srid]
+     (.read (WKTReader. (jts/gf srid)) wkt)))
+
 (defn to-wkt [^Geometry geom] (.write wkt-writer geom))
 
 (defn read-wkb
-  "Read a WKB byte array and convert to a Geometry"
-  [^bytes bytes]
-  (.read wkb-reader bytes))
+  "Read a WKB byte array and convert to a Geometry.
+   Can optionally pass in SRID. Defaults to WGS84"
+  ([^bytes bytes] (.read wkb-reader bytes))
+  ([^bytes bytes srid]
+     (.read (WKBReader. (jts/gf srid)) bytes)))
 
 (defn read-wkb-hex
   "Read a WKB hex string and convert to a Geometry"
-  [^String s]
-  (read-wkb (WKBReader/hexToBytes s)))
+  ([^String s]
+     (read-wkb (WKBReader/hexToBytes s)))
+  ([^String s srid]
+     (read-wkb (WKBReader/hexToBytes s) srid)))
 
 (defn to-wkb
   "Write a WKB, excluding any SRID"

--- a/src/geo/io.clj
+++ b/src/geo/io.clj
@@ -1,20 +1,20 @@
 (ns geo.io
   "Helper functions for converting JTS geometries to and from various
    geospatial IO formats (geojson, wkt, wkb)."
-  (:require [geo.jts]
+  (:require [geo.jts :refer [gf-wgs84]]
             [clojure.data])
   (:import (org.locationtech.jts.io WKTReader WKTWriter WKBReader WKBWriter)
            (org.locationtech.jts.geom Geometry)
            (org.locationtech.jts.io.geojson GeoJsonReader GeoJsonWriter)))
 
-(def ^WKTReader wkt-reader (WKTReader.))
+(def ^WKTReader wkt-reader (WKTReader. gf-wgs84))
 (def ^WKTWriter wkt-writer (WKTWriter.))
 
-(def ^WKBReader wkb-reader (WKBReader.))
+(def ^WKBReader wkb-reader (WKBReader. gf-wgs84))
 (def ^WKBWriter wkb-writer (WKBWriter.))
 (def ^WKBWriter wkb-writer-2d-srid (WKBWriter. 2 true))
 
-(def ^GeoJsonReader geojson-reader (GeoJsonReader.))
+(def ^GeoJsonReader geojson-reader (GeoJsonReader. gf-wgs84))
 (def ^GeoJsonWriter geojson-writer (GeoJsonWriter.))
 
 (.setEncodeCRS geojson-writer false)

--- a/test/geo/t_io.clj
+++ b/test/geo/t_io.clj
@@ -61,9 +61,9 @@
              (-> wkt-2 sut/read-wkt (jts/set-srid 3857) sut/to-wkb-hex) => wkb-2-hex))
 
 (fact "understands projection in hex string"
-      (-> wkb-hex sut/read-wkb-hex jts/get-srid) => 0
+      (-> wkb-hex sut/read-wkb-hex jts/get-srid) => 4326
       (-> ewkb-hex-wgs84 sut/read-wkb-hex jts/get-srid) => 4326
-      (-> wkb-2-hex sut/read-wkb-hex jts/get-srid) => 0
+      (-> wkb-2-hex sut/read-wkb-hex jts/get-srid) => 4326
       (-> ewkb-2-hex-wgs84 sut/read-wkb-hex jts/get-srid) => 4326)
 
 (facts "reads and writes ewkb in hex string"

--- a/test/geo/t_io.clj
+++ b/test/geo/t_io.clj
@@ -66,6 +66,12 @@
       (-> wkb-2-hex sut/read-wkb-hex jts/get-srid) => 4326
       (-> ewkb-2-hex-wgs84 sut/read-wkb-hex jts/get-srid) => 4326)
 
+(fact "reads WKTs and WKBs with custom SRID"
+      (-> wkt sut/read-wkt jts/get-srid) => 4326
+      (-> wkt (sut/read-wkt 2229) jts/get-srid) => 2229
+      (-> wkb-hex sut/read-wkb-hex jts/get-srid) => 4326
+      (-> wkb-hex (sut/read-wkb-hex 2229) jts/get-srid) => 2229)
+
 (facts "reads and writes ewkb in hex string"
        (fact "ewkb-hex identity"
              (-> ewkb-hex-wgs84 sut/read-wkb-hex sut/to-ewkb-hex) => ewkb-hex-wgs84


### PR DESCRIPTION
Doing intersections with geometries created with this package gave me `java.lang.Exception: Geometry does not have an SRID`, turns out the `io` namespace readers defaults to a 0 SRID.