### PR TITLE
Support for H3

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,11 +9,12 @@ coordinates, distances, and polygon intersections. We think this library will
 be particularly useful in concert with our [rich API of geospatial
 information](http://developer.factual.com/).
 
-We unify four open-source JVM geospatial libraries: The [JTS topology
+We unify five open-source JVM geospatial libraries: The [JTS topology
 suite](https://github.com/locationtech/jts),
 [spatial4j](https://github.com/spatial4j/spatial4j),
-[geohash-java](https://github.com/kungfoo/geohash-java), and
-[proj4j](https://github.com/locationtech/geotrellis/tree/master/proj4). Clojure
+[geohash-java](https://github.com/kungfoo/geohash-java),
+[proj4j](https://github.com/locationtech/geotrellis/tree/master/proj4),
+and [h3](https://github.com/uber/h3-java). Clojure
 protocols allow these libraries' disparate representations of points, shapes,
 and spatial reference systems to interoperate, so you can, for instance, ask
 whether a JTS point is within a geohash, whether a geohash intersects a
@@ -172,6 +173,9 @@ box intersections, bounded-space partitioning, and so on.
 Wrapper for the locationtech JTS spatial library. Constructors for points,
 coordinate sequences, rings, polygons, multipolygons, and so on.
 
+Given a certain geometry, can transform using proj4j to a different coordinate
+reference system.
+
 ## geo.geohash
 
 Defines geohashes using the ch.hsr.geohash library, and extends them to support
@@ -194,6 +198,27 @@ in specific.
 Helper functions for dealing with common geospatial serialization formats.
 Use these to read and write from WKT, GeoJSON, WKB in byte and in hex string
 formats, and EWKB in byte and in hex string formats.
+
+## geo.crs
+
+Helper functions for dealing with transforms between coordinate reference
+systems. Can create transformations used in the geo.jts namespace.
+
+## geo.h3
+
+Defines hexagonal cells using the com.uber.h3 library. Extends H3's GeoCoord
+to support the Point protocol.
+
+Given a certain H3 cell, can compute surrounding rings, get the boundary in JTS format,
+or get the resolution.
+
+Given a Shapelike geometry, can polyfill a list of H3 cells at a given level of resolution.
+
+Given a list of H3 cells, can compact the list to remove redundant cells, uncompact the list
+to a desired resolution, or merge contiguous cells into a JTS multipolygon.
+
+Can create unidirectional edges based on different configurations of cells, and can check
+for the 12 pentagonal cells at each resolution.
 
 IO functions return JTS Geometries.
 

--- a/project.clj
+++ b/project.clj
@@ -9,6 +9,7 @@
   :dependencies
   [[org.clojure/math.numeric-tower "0.0.4"]
    [ch.hsr/geohash "1.3.0"]
+   [com.uber/h3 "3.0.3"]
    [org.locationtech.geotrellis/geotrellis-proj4_2.11 "1.2.1"]
    [org.locationtech.spatial4j/spatial4j "0.7"]
    [org.locationtech.jts/jts-core "1.15.1"]

--- a/project.clj
+++ b/project.clj
@@ -1,5 +1,5 @@
 (defproject
-  factual/geo "2.0.0-rc-3"
+  factual/geo "2.1.0-rc-0"
   :url     "https://github.com/factual/geo"
   :license {:name "Eclipse Public License - v 1.0"
             :url  "http://www.eclipse.org/legal/epl-v10.html"

--- a/src/geo/h3.clj
+++ b/src/geo/h3.clj
@@ -1,0 +1,340 @@
+(ns geo.h3
+  "Working with H3."
+  (:require [geo.spatial :as spatial]
+            [geo.jts :as jts]
+            [clojure.walk :as walk])
+  (:import (ch.hsr.geohash GeoHash)
+           (com.uber.h3core H3Core)
+           (com.uber.h3core.util GeoCoord)
+           (geo.spatial Point Shapelike)
+           (org.locationtech.jts.geom LinearRing MultiPolygon Polygon)
+           (org.locationtech.spatial4j.shape.impl RectangleImpl)))
+
+(def ^H3Core h3-inst (H3Core/newInstance))
+
+(defn- long->string
+  "Convert a long representation of an H3 cell to a string."
+  [^Long h]
+  (.h3ToString h3-inst h))
+
+(defn- string->long
+  "Convert a string representation of an H3 cell to a long."
+  [^String h]
+  (.stringToH3 h3-inst h))
+
+(defn- h3->pt-long
+  "Long helper to return a GeoCoord of the center point of a cell."
+  [^Long h]
+  (.h3ToGeo h3-inst h))
+
+(defn- h3->pt-string
+  "String helper to return a GeoCoord of the center point of a cell."
+  [^String h]
+  (.h3ToGeo h3-inst h))
+
+(defn- get-resolution-string
+  "String helper to return the resolution of a cell."
+  [^String h]
+  (.h3GetResolution h3-inst h))
+
+(defn get-resolution-long
+  "Long helper to return the resolution of a cell."
+  [^Long h]
+  (.h3GetResolution h3-inst h))
+
+(defn- hex-ring-string
+  "String helper to return a list of indices with distance 'k' from a cell."
+  [^String h ^Integer k]
+  (.hexRing h3-inst h k))
+
+(defn- hex-ring-long
+  "Long helper to return a list of indices with distance 'k' from a cell."
+  [^Long h ^Integer k]
+  (.hexRing h3-inst h k))
+
+(defn- hex-range-string
+  "String helper to return a list of 'k' rings, each of which is a
+  list of addresses, from closest to farthest."
+  [^String h ^Integer k]
+  (.hexRange h3-inst h k))
+
+(defn- hex-range-long
+  "Long helper to return a list of 'k' rings, each of which is a
+  list of addresses, from closest to farthest."
+  [^Long h ^Integer k]
+  (.hexRange h3-inst h k))
+
+(defn- to-jts-common
+  "Convert a geo boundary to JTS Polygon."
+  [g]
+  (as-> g v
+        (into [] v)
+        (conj v (first v))
+        (map #(jts/coordinate (spatial/longitude %) (spatial/latitude %)) v)
+        (jts/linear-ring v)
+        (jts/polygon v)))
+
+(defn- to-jts-string
+  "String helper for: given an H3 identifier, return a Polygon of that cell."
+  [^String h]
+  (to-jts-common (.h3ToGeoBoundary h3-inst h)))
+
+(defn- to-jts-long
+  "Long helper for: given an H3 identifier, return a Polygon of that cell."
+  [^Long h]
+  (to-jts-common (.h3ToGeoBoundary h3-inst h)))
+
+(defn- edge-string
+  "String helper for: given both 'from' and 'to' cells, get a unidirectional edge index."
+  [^String from ^String to]
+  (.getH3UnidirectionalEdge h3-inst from to))
+
+(defn- edge-long
+  "Long helper for: given both 'from' and 'to' cells, get a unidirectional edge index."
+  [^Long from ^Long to]
+  (.getH3UnidirectionalEdge h3-inst from to))
+
+(defn- edge-origin-string
+  "String helper for: given a unidirectional edge, get its origin."
+  [^String edge]
+  (.getOriginH3IndexFromUnidirectionalEdge h3-inst edge))
+
+(defn- edge-origin-long
+  "Long helper for: given a unidirectional edge, get its origin."
+  [^Long edge]
+  (.getOriginH3IndexFromUnidirectionalEdge h3-inst edge))
+
+(defn- edge-destination-string
+  "String helper for: given a unidirectional edge, get its destination."
+  [^String edge]
+  (.getDestinationH3IndexFromUnidirectionalEdge h3-inst edge))
+
+(defn- edge-destination-long
+  "Long helper for: given a unidirectional edge, get its destination."
+  [^Long edge]
+  (.getDestinationH3IndexFromUnidirectionalEdge h3-inst edge))
+
+(defn- edges-string
+  "String helper to get all edges originating from an index."
+  [^String cell]
+  (into [] (.getH3UnidirectionalEdgesFromHexagon h3-inst cell)))
+
+(defn- edges-long
+  "Long helper to get all edges originating from an index."
+  [^Long cell]
+  (into [] (.getH3UnidirectionalEdgesFromHexagon h3-inst cell)))
+
+(defn- edge-boundary-string
+  "String helper to get coordinates representing the edge."
+  [^String edge]
+  (into [] (.getH3UnidirectionalEdgeBoundary h3-inst edge)))
+
+(defn- edge-boundary-long
+  "Long helper to get coordinates representing the edge."
+  [^Long edge]
+  (into [] (.getH3UnidirectionalEdgeBoundary h3-inst edge)))
+
+(defn- pentagon?-string
+  "String helper to check if an index is a pentagon"
+  [^String cell]
+  (.h3IsPentagon h3-inst cell))
+
+(defn- pentagon?-long
+  "Long helper to check if an index is a pentagon"
+  [^Long cell]
+  (.h3IsPentagon h3-inst cell))
+
+(defn- is-valid?-string
+  "String helper to check if an index is valid"
+  [^String cell]
+  (.h3IsValid h3-inst cell))
+
+(defn- is-valid?-long
+  "Long helper to check if an index is valid"
+  [^Long cell]
+  (.h3IsValid h3-inst cell))
+
+(defn- neighbors?-string
+  "String helper to check if cells are neighbors"
+  [^String c1 ^String c2]
+  (.h3IndexesAreNeighbors h3-inst c1 c2))
+
+(defn- neighbors?-long
+  "String helper to check if cells are neighbors"
+  [^Long c1 ^Long c2]
+  (.h3IndexesAreNeighbors h3-inst c1 c2))
+
+(defprotocol H3Index
+  (to-string [this] "Return index as a string.")
+  (to-long [this] "Return index as a long.")
+  (h3->pt [this] "Return a GeoCoord of the center point of a cell.")
+  (get-resolution [this] "Return the resolution of a cell.")
+  (hex-ring [this k] "Return a list of indices with distance 'k' from a cell.")
+  (hex-range [this k] "Return a list of 'k' rings, each of which is a list of addresses, from closest to farthest.")
+  (to-jts [this] "Given an H3 identifier, return a Polygon of that cell.")
+  (edge [from to] "Given both 'from' and 'to' cells, get a unidirectional edge index.")
+  (edge-origin [this] "Given a unidirectional edge, get its origin.")
+  (edge-destination [this] "Given a unidirectional edge, get its destination.")
+  (edges [this] "Get all edges originating from an index.")
+  (edge-boundary [this] "Get coordinates representing the edge.")
+  (pentagon? [this] "Check if an index is a pentagon.")
+  (is-valid? [this] "Check if an index is valid.")
+  (neighbors? [this cell] "Check if two indexes are neighbors."))
+
+(extend-protocol H3Index
+  String
+  (to-string [this] this)
+  (to-long [this] (string->long this))
+  (h3->pt [this] (h3->pt-string this))
+  (get-resolution [this] (get-resolution-string this))
+  (hex-ring [this k] (hex-ring-string this k))
+  (hex-range [this k] (hex-range-string this k))
+  (to-jts [this] (to-jts-string this))
+  (edge [from to] (edge-string from to))
+  (edge-origin [this] (edge-origin-string this))
+  (edge-destination [this] (edge-destination-string this))
+  (edges [this] (edges-string this))
+  (edge-boundary [this] (edge-boundary-string this))
+  (pentagon? [this] (pentagon?-string this))
+  (is-valid? [this] (is-valid?-string this))
+  (neighbors? [this cell] (neighbors?-string this cell))
+
+  Long
+  (to-string [this] (long->string this))
+  (to-long [this] this)
+  (h3->pt [this] (h3->pt-long this))
+  (get-resolution [this] (get-resolution-long this))
+  (hex-ring [this k] (hex-ring-long this k))
+  (hex-range [this k] (hex-range-long this k))
+  (to-jts [this] (to-jts-long this))
+  (edge [from to] (edge-long from to))
+  (edge-origin [this] (edge-origin-long this))
+  (edge-destination [this] (edge-destination-long this))
+  (edges [this] (edges-long this))
+  (edge-boundary [this] (edge-boundary-long this))
+  (pentagon? [this] (pentagon?-long this))
+  (is-valid? [this] (is-valid?-long this))
+  (neighbors? [this cell] (neighbors?-long this cell)))
+
+(defprotocol Polygonal
+  (to-polygon [this] [this srid] "Ensure that an object is 2D, with lineal boundaries.")
+  (polyfill [this res] "Return all resolution 'res' cells that cover a given Shapelike, excluding internal holes."))
+
+(declare polyfill-p)
+(declare polyfill-mp)
+
+(extend-protocol Polygonal
+  GeoHash
+  (to-polygon ([this] (spatial/to-jts this))
+    ([this srid] (spatial/to-jts this srid)))
+  (polyfill [this res] (polyfill-p this res))
+
+  RectangleImpl
+  (to-polygon ([this] (spatial/to-jts this))
+    ([this srid] (spatial/to-jts this srid)))
+  (polyfill [this res] (polyfill-p this res))
+
+  Polygon
+  (to-polygon ([this] this)
+    ([this srid] (spatial/to-jts this srid)))
+  (polyfill [this res] (polyfill-p this res))
+
+  LinearRing
+  (to-polygon ([this] (jts/polygon this))
+    ([this srid] (jts/polygon (jts/transform-geom this srid))))
+  (polyfill [this res] (polyfill-p this res))
+
+  MultiPolygon
+  (to-polygon ([this] this)
+    ([this srid] (spatial/to-jts this srid)))
+  (polyfill [this res] (polyfill-mp this res)))
+
+(defn pt->h3
+  "Return the index of the resolution 'res' cell that a point or lat/lng pair is contained within."
+  ([^Point pt ^Integer res]
+   (pt->h3 (spatial/latitude pt) (spatial/longitude pt) res))
+  ([^Double lat ^Double lng ^Integer res]
+   (.geoToH3Address h3-inst lat lng res)))
+
+(defn geo-coords
+  "Return all coordinates for a given Shapelike as GeoCoords"
+  [^Shapelike s]
+  (map spatial/h3-point (jts/coordinates (spatial/to-jts s))))
+
+(defn- polyfill-p
+  "Polygon helper to return all resolution 'res' cells that cover a given shape,
+  excluding internal holes."
+  [s ^Integer res]
+  (let [s (to-polygon s jts/default-srid)
+        num-interior-rings (.getNumInteriorRing ^Polygon s)
+        ext-ring (.getExteriorRing ^Polygon s)
+        int-rings (map #(.getInteriorRingN ^Polygon s %) (range num-interior-rings))]
+    (.polyfillAddress h3-inst (geo-coords ext-ring) (map geo-coords int-rings) res)))
+
+(defn- polyfill-mp
+  "Multipolygon helper to return all resolution 'res' cells that cover a given shape,
+   excluding internal holes."
+  [mp ^Integer res]
+  (let [pf-polys (fn [p] (mapcat #(polyfill-p % res) p))]
+    (into [] (-> mp
+                 jts/polygons
+                 pf-polys
+                 flatten))))
+
+(defn compact
+  "Given a set of H3 cells, return a compacted set of cells, at possibly coarser resolutions."
+  [cells]
+  (cond (number? (first cells))
+        (.compact h3-inst cells)
+        (string? (first cells))
+        (.compactAddress h3-inst cells)))
+
+(defn uncompact
+  "Given a set of H3 cells, return an uncompacted set of cells to a certain resolution."
+  [cells res]
+  (cond (number? (first cells))
+        (.uncompact h3-inst cells res)
+        (string? (first cells))
+        (.uncompactAddress h3-inst cells res)))
+
+(defn- geocoord-array-wkt
+  "Create a wkt-style data structure from a collection of GeoCoords."
+  [coords]
+  (->> coords
+       (map (fn [coord] [(spatial/longitude coord) (spatial/latitude coord)]))
+       flatten
+       vec))
+
+(defn- geocoord-multi-helper
+  "Helper function to pass to postwalk for multi-polygon generators."
+  [v]
+  (if (instance? GeoCoord (first v))
+    (geocoord-array-wkt v)
+    v))
+
+
+(defn- multi-polygon-n
+  "Multi-polygon generator for numbers"
+  [cells]
+  (as-> cells v
+        (.h3SetToMultiPolygon h3-inst v true)
+        (mapv #(into [] %) v)
+        (walk/postwalk geocoord-multi-helper v)
+        (jts/multi-polygon-wkt v)))
+
+(defn- multi-polygon-s
+  "Multi-polygon generator for strings"
+  [cells]
+  (as-> cells v
+        (.h3AddressSetToMultiPolygon h3-inst v true)
+        (mapv #(into [] %) v)
+        (walk/postwalk geocoord-multi-helper v)
+        (jts/multi-polygon-wkt v)))
+
+(defn multi-polygon
+  "Given a contiguous set of H3 cells, return a JTS MultiPolygon."
+  [cells]
+  (cond (number? (first cells))
+        (multi-polygon-n cells)
+        (string? (first cells))
+        (multi-polygon-s cells)))

--- a/src/geo/h3.clj
+++ b/src/geo/h3.clj
@@ -2,6 +2,7 @@
   "Working with H3."
   (:require [geo.spatial :as spatial]
             [geo.jts :as jts]
+            [clojure.string :as string]
             [clojure.walk :as walk]
             [clojure.math.numeric-tower :as numeric-tower])
   (:import (ch.hsr.geohash GeoHash)
@@ -276,11 +277,23 @@
   (polyfill-address [this res] (polyfill-address-mp this res)))
 
 (defn pt->h3
-  "Return the index of the resolution 'res' cell that a point or lat/lng pair is contained within."
+  "Return the Long index of the resolution 'res' cell that a point or lat/lng pair is contained within."
   ([^Point pt ^Integer res]
    (pt->h3 (spatial/latitude pt) (spatial/longitude pt) res))
   ([^Double lat ^Double lng ^Integer res]
-   (.geoToH3Address h3-inst lat lng res)))
+   (try (.geoToH3 h3-inst lat lng res)
+        (catch Exception e
+          (throw (Exception. (string/join ["Failed to complete pt->h3 for lat " lat ", long " lng, ", res " res ". H3 exception message: " e])))))))
+
+(defn pt->h3-address
+  "Return the String index of the resolution 'res' cell that a point or lat/lng pair is contained within."
+  ([^Point pt ^Integer res]
+   (pt->h3-address (spatial/latitude pt) (spatial/longitude pt) res))
+  ([^Double lat ^Double lng ^Integer res]
+   (try (.geoToH3Address h3-inst lat lng res)
+        (catch Exception e
+          (throw (Exception. (string/join ["Failed to complete pt->h3-address for lat " lat ", long " lng, ", res " res ". H3 exception message: " e])))))))
+
 
 (defn geo-coords
   "Return all coordinates for a given Shapelike as GeoCoords"

--- a/src/geo/h3.clj
+++ b/src/geo/h3.clj
@@ -42,27 +42,27 @@
   [^Long h]
   (.h3GetResolution h3-inst h))
 
-(defn- hex-ring-string
-  "String helper to return a list of indices with distance 'k' from a cell."
+(defn- k-ring-string
+  "String helper to return a list of neighboring indices in all directions for 'k' rings."
   [^String h ^Integer k]
-  (.hexRing h3-inst h k))
+  (.kRing h3-inst h k))
 
-(defn- hex-ring-long
-  "Long helper to return a list of indices with distance 'k' from a cell."
+(defn- k-ring-long
+  "Long helper to return a list of neighboring indices in all directions for 'k' rings."
   [^Long h ^Integer k]
-  (.hexRing h3-inst h k))
+  (.kRing h3-inst h k))
 
-(defn- hex-range-string
-  "String helper to return a list of 'k' rings, each of which is a
-  list of addresses, from closest to farthest."
+(defn- k-ring-distances-string
+  "String helper to return a list of neighboring indices in all directions for 'k' rings,
+  ordered by distance from the origin index."
   [^String h ^Integer k]
-  (.hexRange h3-inst h k))
+  (.kRingDistances h3-inst h k))
 
-(defn- hex-range-long
-  "Long helper to return a list of 'k' rings, each of which is a
-  list of addresses, from closest to farthest."
+(defn- k-ring-distances-long
+  "String helper to return a list of neighboring indices in all directions for 'k' rings,
+  ordered by distance from the origin index."
   [^Long h ^Integer k]
-  (.hexRange h3-inst h k))
+  (.kRingDistances h3-inst h k))
 
 (defn- to-jts-common
   "Convert a geo boundary to JTS Polygon."
@@ -169,8 +169,8 @@
   (to-long [this] "Return index as a long.")
   (h3->pt [this] "Return a GeoCoord of the center point of a cell.")
   (get-resolution [this] "Return the resolution of a cell.")
-  (hex-ring [this k] "Return a list of indices with distance 'k' from a cell.")
-  (hex-range [this k] "Return a list of 'k' rings, each of which is a list of addresses, from closest to farthest.")
+  (k-ring [this k] "Return a list of neighboring indices in all directions for 'k' rings.")
+  (k-ring-distances [this k] "Return a list of neighboring indices in all directions for 'k' rings, ordered by distance from the origin index.")
   (to-jts [this] "Given an H3 identifier, return a Polygon of that cell.")
   (edge [from to] "Given both 'from' and 'to' cells, get a unidirectional edge index.")
   (edge-origin [this] "Given a unidirectional edge, get its origin.")
@@ -187,8 +187,8 @@
   (to-long [this] (string->long this))
   (h3->pt [this] (h3->pt-string this))
   (get-resolution [this] (get-resolution-string this))
-  (hex-ring [this k] (hex-ring-string this k))
-  (hex-range [this k] (hex-range-string this k))
+  (k-ring [this k] (k-ring-string this k))
+  (k-ring-distances [this k] (k-ring-distances-string this k))
   (to-jts [this] (to-jts-string this))
   (edge [from to] (edge-string from to))
   (edge-origin [this] (edge-origin-string this))
@@ -204,8 +204,8 @@
   (to-long [this] this)
   (h3->pt [this] (h3->pt-long this))
   (get-resolution [this] (get-resolution-long this))
-  (hex-ring [this k] (hex-ring-long this k))
-  (hex-range [this k] (hex-range-long this k))
+  (k-ring [this k] (k-ring-long this k))
+  (k-ring-distances [this k] (k-ring-distances-long this k))
   (to-jts [this] (to-jts-long this))
   (edge [from to] (edge-long from to))
   (edge-origin [this] (edge-origin-long this))

--- a/src/geo/io.clj
+++ b/src/geo/io.clj
@@ -7,7 +7,7 @@
             [clojure.walk :refer [keywordize-keys stringify-keys]])
   (:import (java.util Arrays Arrays$ArrayList)
            (org.locationtech.jts.io WKTReader WKTWriter WKBReader WKBWriter)
-           (org.locationtech.jts.geom Geometry)
+           (org.locationtech.jts.geom Geometry GeometryCollection)
            (org.wololo.geojson Feature FeatureCollection GeoJSONFactory)
            (org.wololo.jts2geojson GeoJSONReader GeoJSONWriter)))
 
@@ -89,6 +89,12 @@
 (extend-protocol GeoJSONFeatures
   org.wololo.geojson.Geometry
   (to-features [this] [{:properties {} :geometry (read-geometry this)}])
+  org.wololo.geojson.GeometryCollection
+  (to-features [this] (mapcat to-features (jts/geometries (read-geometry this))))
+  Geometry
+  (to-features [this] [{:properties {} :geometry this}])
+  GeometryCollection
+  (to-features [this] (mapcat to-features (jts/geometries this)))
   Feature
   (to-features [this] [{:properties (properties this) :geometry (read-geometry this)}])
   FeatureCollection

--- a/src/geo/jts.clj
+++ b/src/geo/jts.clj
@@ -96,7 +96,7 @@
                  (-> c
                      (.getGeometryN n)
                      (set-srid srid)))]
-    (into [] (map #(geom-n c %) (range n)))))
+    (mapv #(geom-n c %) (range n))))
 
 (defn wkt->coords-array
   [flat-coord-list]
@@ -195,7 +195,7 @@
                  (-> m
                      (.getGeometryN n)
                      (set-srid srid)))]
-    (into [] (map #(geom-n m %) (range n)))))
+    (mapv #(geom-n m %) (range n))))
 
 (defn multi-polygon-wkt
   "Creates a MultiPolygon from a WKT-style data structure, e.g. [[[0 0 1 0 2 2

--- a/src/geo/spatial.clj
+++ b/src/geo/spatial.clj
@@ -263,7 +263,7 @@
 (defn h3-point
   "Returns a GeoCoord used by the H3 library."
   ([point]
-   (GeoCoord. (latitude point) (longitude point)))
+   (h3-point (latitude point) (longitude point)))
   ([lat long]
    (GeoCoord. lat long)))
 

--- a/test/geo/t_h3.clj
+++ b/test/geo/t_h3.clj
@@ -18,9 +18,11 @@
 
 (facts "h3 core functions"
        (fact "from coordinates"
-             (sut/pt->h3 h3-example-latitude h3-example-longitude 7) => h3-example-str)
+             (sut/pt->h3 h3-example-latitude h3-example-longitude 7) => h3-example-long
+             (sut/pt->h3-address h3-example-latitude h3-example-longitude 7) => h3-example-str)
        (fact "from point"
-             (sut/pt->h3 (jts/point h3-example-latitude h3-example-longitude) 7) => h3-example-str)
+             (sut/pt->h3 (jts/point h3-example-latitude h3-example-longitude) 7) => h3-example-long
+             (sut/pt->h3-address (jts/point h3-example-latitude h3-example-longitude) 7) => h3-example-str)
        (fact "strings and longs"
              (sut/to-long h3-example-str) => h3-example-long
              (sut/to-string h3-example-long) => h3-example-str)

--- a/test/geo/t_h3.clj
+++ b/test/geo/t_h3.clj
@@ -114,6 +114,11 @@
              (< (float (/ (count (sut/polyfill (geo.geohash/geohash "dr") 9))
                           (count (sut/polyfill (geo.geohash/geohash "dr") 8)))) 7)
              => truthy)
+       (fact "polyfill is graceful on bad shapes"
+             (sut/polyfill (geo.io/read-wkt "POLYGON EMPTY") 10)
+             => []
+             (sut/polyfill-address (geo.io/read-wkt "POLYGON EMPTY") 10)
+             => [])
        (fact "multi-polygon"
              (count (jts/coordinates
                       (sut/multi-polygon (sut/polyfill geohash-with-hole 12)))) => 402)

--- a/test/geo/t_h3.clj
+++ b/test/geo/t_h3.clj
@@ -1,0 +1,93 @@
+(ns geo.t-h3
+  (:require [geo.h3 :as sut]
+            [geo.geohash :as geohash]
+            [geo.io :as io]
+            [geo.jts :as jts]
+            [geo.spatial :as spatial]
+            [midje.sweet :refer [fact facts falsey truthy]])
+  (:import (org.locationtech.jts.geom Geometry Polygon)
+           (com.uber.h3core.util GeoCoord)))
+
+(def geohash-with-hole (jts/set-srid (.difference (spatial/to-jts (geohash/geohash "u4pruy"))
+                                                  (spatial/to-jts (geohash/geohash "u4pruyk")))
+                                     jts/default-srid))
+(def h3-example-str "871f24ac5ffffff")
+(def h3-example-long 608533827635118079)
+(def h3-example-latitude 57.64911063015461)
+(def h3-example-longitude 10.407439693808556)
+
+(facts "h3 core functions"
+       (fact "from coordinates"
+             (sut/pt->h3 h3-example-latitude h3-example-longitude 7) => h3-example-str)
+       (fact "from point"
+             (sut/pt->h3 (jts/point h3-example-latitude h3-example-longitude) 7) => h3-example-str)
+       (fact "strings and longs"
+             (sut/to-long h3-example-str) => h3-example-long
+             (sut/to-string h3-example-long) => h3-example-str)
+       (fact "resolution"
+             (sut/get-resolution h3-example-str) => 7
+             (sut/get-resolution (sut/to-long h3-example-str)) => 7)
+       (fact "jts boundary"
+             (type (sut/to-jts h3-example-str)) => Polygon)
+       (fact "geo coord"
+             (type (first (sut/geo-coords (geohash/geohash "u4pruy")))) => GeoCoord)
+       (fact "edges"
+             (sut/edge "871f24ac4ffffff" "871f24ac0ffffff") => "1371f24ac4ffffff"
+             (sut/edge-origin "1371f24ac4ffffff") => "871f24ac4ffffff"
+             (sut/edge-destination "1371f24ac4ffffff") => "871f24ac0ffffff"
+             (sut/edges "871f24ac4ffffff") => ["1171f24ac4ffffff" "1271f24ac4ffffff" "1371f24ac4ffffff"
+                                               "1471f24ac4ffffff" "1571f24ac4ffffff" "1671f24ac4ffffff"]
+             (type (first (sut/edge-boundary "1371f24ac4ffffff"))) => GeoCoord)
+       (fact "h3->pt"
+             (str (spatial/to-jts (sut/h3->pt h3-example-str)))
+             => "POINT (10.423520614389421 57.65506363212537)")
+       (fact "pentagon"
+             (sut/pentagon? "8f28308280f18f2") => falsey
+             (sut/pentagon? "821c07fffffffff") => truthy)
+       (fact "validity checks"
+             (sut/is-valid? h3-example-long) => truthy
+             (sut/is-valid? -1) => falsey
+             (sut/is-valid? h3-example-str) => truthy)
+       (fact "neighbor checks"
+             (sut/neighbors? "871f24ac4ffffff" "871f24ac0ffffff") => truthy
+             (sut/neighbors? 608533827618340863 608533827551231999) => truthy
+             (sut/neighbors? "871f24ac0ffffff" "871f24aeeffffff") => falsey))
+
+
+(facts "h3 algorithms"
+       (fact "rings"
+             (sut/hex-ring h3-example-str 0) => ["871f24ac5ffffff"]
+             (sut/hex-ring h3-example-str 1) => ["871f24ae3ffffff" "871f24ac4ffffff" "871f24ac0ffffff"
+                                                 "871f24ac1ffffff" "871f24aeaffffff" "871f24aeeffffff"]
+             (sut/hex-range h3-example-str 1) => [["871f24ac5ffffff"]
+                                                  ["871f24ac4ffffff" "871f24ac0ffffff" "871f24ac1ffffff"
+                                                   "871f24aeaffffff" "871f24aeeffffff" "871f24ae3ffffff"]])
+       (fact "polyfill"
+             (sut/polyfill (geohash/geohash "u4pruy") 9) => ["891f24ac54bffff"
+                                                             "891f24ac097ffff"
+                                                             "891f24ac0b3ffff"
+                                                             "891f24ac543ffff"
+                                                             "891f24ac55bffff"]
+             (-> (jts/multi-polygon [(spatial/to-jts (geohash/geohash "u4pruy"))
+                                     (spatial/to-jts (geohash/geohash "u4pruu"))])
+                 (sut/polyfill 9))
+             => ["891f24ac54bffff" "891f24ac097ffff" "891f24ac0b3ffff" "891f24ac543ffff"
+                 "891f24ac55bffff" "891f24ac00fffff" "891f24ac00bffff" "891f24ac007ffff"
+                 "891f24ac003ffff"]
+             (count (sut/polyfill geohash-with-hole 12)) => 1648)
+       (fact "compact/uncompact"
+             (count (sut/compact (sut/polyfill geohash-with-hole 12))) => 310
+             (count (sut/uncompact (sut/polyfill geohash-with-hole 12) 13)) => 11536)
+       (fact "multi-polygon"
+             (count (jts/coordinates
+                      (sut/multi-polygon (sut/polyfill geohash-with-hole 12)))) => 402)
+       (fact "interoperability with geometry collections"
+             (->> (sut/hex-range h3-example-str 3)
+                  (map sut/multi-polygon)
+                  jts/geometry-collection
+                  io/to-features
+                  (#(nth % 1))
+                  :geometry
+                  jts/coordinates
+                  count)
+             => 26))

--- a/test/geo/t_h3.clj
+++ b/test/geo/t_h3.clj
@@ -56,12 +56,24 @@
 
 (facts "h3 algorithms"
        (fact "rings"
-             (sut/hex-ring h3-example-str 0) => ["871f24ac5ffffff"]
-             (sut/hex-ring h3-example-str 1) => ["871f24ae3ffffff" "871f24ac4ffffff" "871f24ac0ffffff"
-                                                 "871f24ac1ffffff" "871f24aeaffffff" "871f24aeeffffff"]
-             (sut/hex-range h3-example-str 1) => [["871f24ac5ffffff"]
-                                                  ["871f24ac4ffffff" "871f24ac0ffffff" "871f24ac1ffffff"
-                                                   "871f24aeaffffff" "871f24aeeffffff" "871f24ae3ffffff"]])
+             (sut/k-ring h3-example-str 0) => ["871f24ac5ffffff"]
+             (sut/k-ring h3-example-str 1) => ["871f24ac5ffffff" "871f24ac4ffffff" "871f24ac0ffffff"
+                                               "871f24ac1ffffff" "871f24aeaffffff" "871f24aeeffffff"
+                                               "871f24ae3ffffff"]
+             (sut/k-ring h3-example-str 2) => ["871f24ac5ffffff" "871f24ac4ffffff" "871f24ac0ffffff"
+                                               "871f24ac1ffffff" "871f24aeaffffff" "871f24aeeffffff"
+                                               "871f24ae3ffffff" "871f24ae2ffffff" "871f24af1ffffff"
+                                               "871f24ac6ffffff" "871f24ac2ffffff" "871f24ac3ffffff"
+                                               "871f24aceffffff" "871f24accffffff" "871f24aebffffff"
+                                               "871f24ae8ffffff" "871f24aecffffff" "871f24ae1ffffff"
+                                               "871f24ae0ffffff"]
+             (sut/k-ring-distances h3-example-str 2) => [["871f24ac5ffffff"]
+                                                         ["871f24ac4ffffff" "871f24ac0ffffff" "871f24ac1ffffff"
+                                                          "871f24aeaffffff" "871f24aeeffffff" "871f24ae3ffffff"]
+                                                         ["871f24ae2ffffff" "871f24af1ffffff" "871f24ac6ffffff"
+                                                          "871f24ac2ffffff" "871f24ac3ffffff" "871f24aceffffff"
+                                                          "871f24accffffff" "871f24aebffffff" "871f24ae8ffffff"
+                                                          "871f24aecffffff" "871f24ae1ffffff" "871f24ae0ffffff"]])
        (fact "polyfill"
              (sut/polyfill (geohash/geohash "u4pruy") 9) => ["891f24ac54bffff"
                                                              "891f24ac097ffff"
@@ -82,7 +94,7 @@
              (count (jts/coordinates
                       (sut/multi-polygon (sut/polyfill geohash-with-hole 12)))) => 402)
        (fact "interoperability with geometry collections"
-             (->> (sut/hex-range h3-example-str 3)
+             (->> (sut/k-ring-distances h3-example-str 3)
                   (map sut/multi-polygon)
                   jts/geometry-collection
                   io/to-features

--- a/test/geo/t_io.clj
+++ b/test/geo/t_io.clj
@@ -159,3 +159,10 @@
       (map (comp jts/get-srid :geometry) (sut/read-geojson geometry 2229)) => [2229]
       (map (comp jts/get-srid :geometry) (sut/read-geojson feature 2229)) => [2229]
       (map (comp jts/get-srid :geometry) (sut/read-geojson feature-collection-1 2229)) => [2229])
+
+(fact "convert geometrycollection to features"
+      (let [gc (jts/geometry-collection [(sut/read-geojson-geometry null-island-geometry)
+                                         (sut/read-geojson-geometry one-island-geometry)])
+            features (sut/to-features gc)]
+       (:geometry (first features)))
+      => (sut/read-geojson-geometry null-island-geometry))


### PR DESCRIPTION
- [x] Adds h3 as dependency and adds the GeoCoord class to Point/Shapelike
- [x] Create an h3 namespace
- [x] Add basic conversion functions (`to-string`, `to-long`, `pt->h3`, `h3->pt`)
- [x] Add basic operations (`get-resolution`, `hex-ring`, `hex-range`, `jts-boundary`, `geo-coords`, `polyfill`, `compact`, `uncompact`)
- [x] Add additional functionality (`edge` functions, `multi-polygon`, `pentagon?` check, `is-valid?` check, `neighbors?` check)
- [x] Add `polygons` helper function to jts as inverse of `geo.jts/multi-polygon`, to create polygons that can be passed to polyfill.
- [x] Add `geometries` helper function to jts as inverse of `geo.jts/geometry-collection`, to create geometries from a collection.
- [x] Add tests
- [x] Add type hints