### PR TITLE
Remove spatial4j clone workaround, and change JTS clone to copy

### DIFF
--- a/src/geo/jts.clj
+++ b/src/geo/jts.clj
@@ -241,4 +241,4 @@
   ([g crs1 crs2]
    (if (= crs1 crs2)
      (tf-set-srid g crs2)
-     (tf (.clone g) crs1 crs2))))
+     (tf (.copy g) crs1 crs2))))

--- a/src/geo/spatial.clj
+++ b/src/geo/spatial.clj
@@ -126,9 +126,9 @@
   (to-shape [this]
     ;; Cloning geometries that cross dateline to workaround
     ;; spatial4j / jts conversion issue: https://github.com/locationtech/spatial4j/issues/150
-    (let [this-wgs84 (jts/transform-geom this 4326)
+    (let [this-wgs84 (jts/transform-geom this jts/default-srid)
           geom (if (crosses-dateline? this-wgs84)
-                   (.clone this-wgs84)
+                   (.copy this-wgs84)
                  this-wgs84)
           dateline-180-check? true
           allow-multi-overlap? true]

--- a/src/geo/spatial.clj
+++ b/src/geo/spatial.clj
@@ -123,16 +123,7 @@
           ([this srid] (to-jts (to-jts this) srid)))
 
   Geometry
-  (to-shape [this]
-    ;; Cloning geometries that cross dateline to workaround
-    ;; spatial4j / jts conversion issue: https://github.com/locationtech/spatial4j/issues/150
-    (let [this-wgs84 (jts/transform-geom this jts/default-srid)
-          geom (if (crosses-dateline? this-wgs84)
-                   (.copy this-wgs84)
-                 this-wgs84)
-          dateline-180-check? true
-          allow-multi-overlap? true]
-      (.makeShape jts-earth geom dateline-180-check? allow-multi-overlap?)))
+  (to-shape [this] (.makeShape jts-earth (jts/transform-geom this jts/default-srid) true true))
   (to-jts ([this] this)
           ([this srid] (jts/transform-geom this srid))))
 


### PR DESCRIPTION
JTS 1.15 [deprecated clone for copy](https://github.com/locationtech/jts/commit/a7a4442a1ec1ff4bc5790e1bc6cfc157ae44d6f1), so this library should switch accordingly. Additionally, spatial4j 0.7 [includes a fix](https://github.com/locationtech/spatial4j/pull/155) for the reported dateline workaround, so this removes that workaround and streamlines `to-shape` for Geometry.