### PR TITLE
Bump midje to 1.9.2 and lein-codox to 0.10.4

### DIFF
--- a/project.clj
+++ b/project.clj
@@ -19,9 +19,9 @@
   :global-vars {*warn-on-reflection* true}
   :codox {:themes [:rdash]}
   :profiles {:dev {:plugins [[lein-midje "3.2.1"]
-                             [lein-codox "0.10.3"]]
+                             [lein-codox "0.10.4"]]
                    :dependencies [[org.clojure/clojure "1.9.0"]
                                   [codox-theme-rdash "0.1.2"]
                                   [criterium "0.4.4"]
                                   [cheshire "5.8.0"]
-                                  [midje "1.9.1"]]}})
+                                  [midje "1.9.2"]]}})


### PR DESCRIPTION
Midje 1.9.2 fixes the internal reflection warnings from its suchwow dependency, which will partially reduce the noise now generated during testing.