### PR TITLE
Bump h3 dependency to 3.0.4

### DIFF
--- a/project.clj
+++ b/project.clj
@@ -9,7 +9,7 @@
   :dependencies
   [[org.clojure/math.numeric-tower "0.0.4"]
    [ch.hsr/geohash "1.3.0"]
-   [com.uber/h3 "3.0.3"]
+   [com.uber/h3 "3.0.4"]
    [org.locationtech.geotrellis/geotrellis-proj4_2.11 "1.2.1"]
    [org.locationtech.spatial4j/spatial4j "0.7"]
    [org.locationtech.jts/jts-core "1.15.1"]


### PR DESCRIPTION
This bumps the h3 core to 3.0.8, which is a bugfix.