### PR TITLE
Reflection for version 2.0

### DIFF
--- a/src/geo/crs.clj
+++ b/src/geo/crs.clj
@@ -4,9 +4,9 @@
                              CoordinateTransformFactory
                              CRSFactory)))
 
-(defn starts-with? [string prefix]
+(defn starts-with? [^String string prefix]
   (.startsWith string prefix))
-(defn includes? [string substring]
+(defn includes? [^String string substring]
   (.contains string substring))
 
 (def epsg-str? (partial re-matches #"EPSG:(\d+)"))


### PR DESCRIPTION
A reflection warning crept back into CRS when fixing compatibility for older clojure versions. It makes me think it may be worth fixing the test suite's reflection warnings after all, so new warnings don't get lost in the noise. This PR fixes the new CRS reflection, and then uses hinted helper functions so that the interop functions in the tests themselves don't each need hints.

Separately, there's one remaining reflection warning in flare (a midje dependency), but it hasn't been updated in years, and so it seems unlikely that midje will be able to eliminate it any time soon. Seeing as how [CircleCI has moved away from midje](https://circleci.com/blog/rewriting-your-test-suite-in-clojure-in-24-hours/), would you all be interested in moving the tests back to clojure.test? Midje isn't doing anything too fancy here, so I suspect it could be a pretty straightforward move.