### PR TITLE
Bump midje to 1.9.3

### DIFF
--- a/project.clj
+++ b/project.clj
@@ -24,6 +24,6 @@
                                   [codox-theme-rdash "0.1.2"]
                                   [criterium "0.4.4"]
                                   [cheshire "5.8.1"]
-                                  [midje "1.9.2"]]}
+                                  [midje "1.9.3"]]}
              :1.8 {:dependencies [[org.clojure/clojure "1.8.0"]]}
              :1.7 {:dependencies [[org.clojure/clojure "1.7.0"]]}})


### PR DESCRIPTION
@worace sorry, one more of these today that I wish I'd stuck in #38. Today's midje release fixes compatibility with JDK 11 (its dependencies were subject to [this bug](https://dev.clojure.org/jira/browse/CRRBV-18)), allowing geo's test suite to run on it.