### PR TITLE
Bump jts2geojson, h3, midje, and proj4 dependencies

### DIFF
--- a/project.clj
+++ b/project.clj
@@ -9,13 +9,13 @@
   :dependencies
   [[org.clojure/math.numeric-tower "0.0.4"]
    [ch.hsr/geohash "1.3.0"]
-   [com.uber/h3 "3.1.0"]
+   [com.uber/h3 "3.2.0"]
    [org.locationtech.geotrellis/geotrellis-proj4_2.11 "2.0.0"]
    [org.locationtech.spatial4j/spatial4j "0.7"]
    [org.locationtech.jts/jts-core "1.16.0"]
    [org.locationtech.jts.io/jts-io-common "1.16.0"]
    [org.noggit/noggit "0.8"]
-   [org.wololo/jts2geojson "0.12.0"]]
+   [org.wololo/jts2geojson "0.13.0"]]
   :codox {:themes [:rdash]}
   :profiles {:dev {:global-vars {*warn-on-reflection* true}
                    :plugins [[lein-midje "3.2.1"]

--- a/project.clj
+++ b/project.clj
@@ -10,7 +10,7 @@
   [[org.clojure/math.numeric-tower "0.0.4"]
    [ch.hsr/geohash "1.3.0"]
    [com.uber/h3 "3.2.0"]
-   [org.locationtech.geotrellis/geotrellis-proj4_2.11 "2.0.0"]
+   [org.locationtech.geotrellis/geotrellis-proj4_2.11 "2.1.0"]
    [org.locationtech.spatial4j/spatial4j "0.7"]
    [org.locationtech.jts/jts-core "1.16.0"]
    [org.locationtech.jts.io/jts-io-common "1.16.0"]

--- a/project.clj
+++ b/project.clj
@@ -24,6 +24,6 @@
                                   [codox-theme-rdash "0.1.2"]
                                   [criterium "0.4.4"]
                                   [cheshire "5.8.1"]
-                                  [midje "1.9.3"]]}
+                                  [midje "1.9.4"]]}
              :1.8 {:dependencies [[org.clojure/clojure "1.8.0"]]}
              :1.7 {:dependencies [[org.clojure/clojure "1.7.0"]]}})


### PR DESCRIPTION
These are pretty small version bumps, but just keeping up with upstream. jts2geojson was updated to use jts 1.16, and h3 has function changes that don't really affect `geo`'s current functionality. It seems wise to me that `geo` not use any of the `h3` experimental functions until they stabilize, to minimize future breaking changes. midje 1.9.4 eliminates all the new boxed math warnings that appear with core.rrb-vector.