### PR TITLE
Add support for openjdk11 in travis testing

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,2 +1,6 @@
 language: clojure
 script: lein with-profile dev:+1.8:+1.7 midje
+jdk:
+  - oraclejdk8
+  - openjdk8
+  - openjdk11


### PR DESCRIPTION
Re #39, it may be good to starting testing against both java 8 and 11.