### PR TITLE
Rename proj4-string? to proj4-str? for API consistency

### DIFF
--- a/src/geo/crs.clj
+++ b/src/geo/crs.clj
@@ -38,10 +38,13 @@
   (some (fn [prefix] (starts-with? crs-str (str prefix ":")))
         valid-crs-prefixes))
 
-(defn proj4-string?
+(defn proj4-str?
   "Check if input appears to be a proj4 string"
   [crs-str]
   (includes? crs-str "+proj="))
+
+;; Maintain old proj4-string? function name until at least version 3.0, but deprecate.
+(def proj4-string? proj4-str?)
 
 (defn- create-crs-int
   [^Integer c]
@@ -63,7 +66,7 @@
         (create-crs-int c)
         (crs-name? c)
         (create-crs-name c)
-        (proj4-string? c)
+        (proj4-str? c)
         (create-crs-parameters c)))
 
 (defn ^CoordinateTransform create-transform

--- a/test/geo/t_crs.clj
+++ b/test/geo/t_crs.clj
@@ -13,8 +13,10 @@
        (fact (->> sut/valid-crs-prefixes
                   (map #(str % ":2000"))
                   (every? sut/crs-name?)) => true)
+       (fact "+proj=merc +lat_ts=56.5 +ellps=GRS80" => sut/proj4-str?)
+       (fact "pizza" => (comp not sut/proj4-str?))
+       ; Maintain alias of proj4-str? until at least version 3.0
        (fact "+proj=merc +lat_ts=56.5 +ellps=GRS80" => sut/proj4-string?)
-       (fact "pizza" => (comp not sut/proj4-string?))
        (fact (sut/epsg-str->srid "EPSG:4326") => 4326)
        (fact (sut/epsg-str->srid "pizza") => (m/throws AssertionError))
        (fact (sut/epsg-str->srid "EPSG:4326.0") => (m/throws AssertionError)))


### PR DESCRIPTION
The CRS namespace has a naming convention of `epsg-str?` and `create-crs-int`, so `proj4-string?` would need to be named `proj4-str?` for consistency. We can `(def proj4-string? proj4-str?)` so existing code doesn't break, but it may also be good to consider that function name deprecated until at least the next breaking major version.