### PR TITLE
Allow transform-geom to use externally created coordinate transforms

### DIFF
--- a/src/geo/crs.clj
+++ b/src/geo/crs.clj
@@ -1,6 +1,7 @@
 (ns geo.crs
   "Helper functions for identifying and manipulating Coordinate Reference Systems."
   (:import (org.locationtech.proj4j CoordinateReferenceSystem
+                                    CoordinateTransform
                                     CoordinateTransformFactory
                                     CRSFactory)))
 
@@ -55,6 +56,21 @@
   [^String c]
   (.createFromParameters crs-factory "" c))
 
+(defn get-name
+  "Get the name of a coordinate reference system."
+  [^CoordinateReferenceSystem c]
+  (.getName c))
+
+(defn get-source-crs
+  "Get the source coordinate reference system of a transform."
+  [^CoordinateTransform t]
+  (.getSourceCRS t))
+
+(defn get-target-crs
+  "Get the source coordinate reference system of a transform."
+  [^CoordinateTransform t]
+  (.getTargetCRS t))
+
 (defprotocol Transformable
   (create-crs [this] "Create a CRS system. If given an integer or long, assume it is an EPSG code.
                       If given a valid CRS name or proj4 string, use that as the CRS identifier.
@@ -82,7 +98,7 @@
 
   CoordinateReferenceSystem
   (create-crs [this] this)
-  (get-srid [this] (get-srid (.getName this))))
+  (get-srid [this] (get-srid (get-name this))))
 
 (defn create-transform
   [c1 c2]

--- a/src/geo/jts.clj
+++ b/src/geo/jts.clj
@@ -37,8 +37,8 @@
 
 (defn set-srid
   "Sets a geometry's SRID to a new value, and returns that geometry."
-  [^Geometry geom ^Integer srid]
-  (doto geom (.setSRID srid)))
+  [^Geometry geom crs]
+  (doto geom (.setSRID (crs/get-srid crs))))
 
 (defn ^GeometryFactory get-factory
   "Gets a GeometryFactory for a given geometry."
@@ -264,9 +264,9 @@
 
 (defn- tf
   "Transform a Geometry.
-  When two CRSs are passed as arguments, transform from one CRS to another.
-  When the target transformation can be identified with an EPSG code, set the Geometry's SRID to that integer.
-  When only a single CoordinateTransform is passed, set the SRID to 0."
+  When a single CoordinateTransform is passed, apply that transform to the Geometry. When the target CRS
+  has an SRID, set the geometry's SRID to that.
+  When two CRSs are passed as arguments, generate an appropriate CoordinateTransform and apply accordingly."
   ([^Geometry g ^CoordinateTransform transform]
    (let [g (.copy g)]
      (.apply g (transform-coord-seq-filter transform))

--- a/src/geo/jts.clj
+++ b/src/geo/jts.clj
@@ -283,7 +283,7 @@
            (assert (not= 0 geom-srid) "Geometry must have a valid SRID to be transformed")
            (if (= (crs/get-srid t) geom-srid)
              g
-             (tf g geom-srid t)))))
+             (transform-geom g geom-srid t)))))
   ([g c1 c2]
    (tf g c1 c2)))
 

--- a/src/geo/jts.clj
+++ b/src/geo/jts.clj
@@ -268,10 +268,9 @@
   When the target transformation can be identified with an EPSG code, set the Geometry's SRID to that integer.
   When only a single CoordinateTransform is passed, set the SRID to 0."
   ([^Geometry g ^CoordinateTransform transform]
-   (let [g (.copy g)
-         target-srid (crs/get-srid (crs/get-target-crs transform))]
+   (let [g (.copy g)]
      (.apply g (transform-coord-seq-filter transform))
-     (set-srid g target-srid)))
+     (set-srid g (crs/get-srid (crs/get-target-crs transform)))))
   ([^Geometry g c1 c2]
    (tf g (crs/create-transform c1 c2))))
 

--- a/src/geo/jts.clj
+++ b/src/geo/jts.clj
@@ -1,7 +1,7 @@
 (ns geo.jts
   "Wrapper for the locationtech JTS spatial library. Constructors for points,
   coordinate sequences, rings, polygons, multipolygons, and so on."
-  (:require [geo.crs :as crs])
+  (:require [geo.crs :as crs :refer [Transformable]])
   (:import (org.locationtech.jts.geom Coordinate
                                       CoordinateSequence
                                       CoordinateSequenceFilter
@@ -252,7 +252,7 @@
     (.setOrdinate cseq i 1 (.y transformed))))
 
 (defn- ^CoordinateSequenceFilter transform-coord-seq-filter
-  "Implement JTS's CoordinateSequenceFilter, to be applied to a Geometry using transform-geom."
+  "Implement JTS's CoordinateSequenceFilter, to be applied to a Geometry using tf and transform-geom."
   [transform]
   (reify CoordinateSequenceFilter
     (filter [_ seq i]
@@ -262,45 +262,32 @@
     (isGeometryChanged [_]
       true)))
 
-(defn- tf-set-srid
-  "When the final projection for a tf is an SRID or EPSG, set the Geometry's SRID."
-  [g c]
-  (cond (integer? c) (set-srid g c)
-        (crs/epsg-str? c) (set-srid g (crs/epsg-str->srid c))
-        :else g))
-
 (defn- tf
   "Transform a Geometry.
   When two CRSs are passed as arguments, transform from one CRS to another.
-  When the target transformation is an EPSG code, set the Geometry's SRID to that integer.
-  When only a single CoordinateTransform is passed, do not attempt to change the Geometry's SRID."
+  When the target transformation can be identified with an EPSG code, set the Geometry's SRID to that integer.
+  When only a single CoordinateTransform is passed, set the SRID to 0."
   ([^Geometry g ^CoordinateTransform transform]
-   (.apply g (transform-coord-seq-filter transform))
-   (tf-set-srid g 0))
+   (let [g (.copy g)]
+     (.apply g (transform-coord-seq-filter transform))
+     (set-srid g 0)))
   ([^Geometry g c1 c2]
-   (let [tcsf (transform-coord-seq-filter (crs/create-transform c1 c2))]
-     (.apply g tcsf)
-     (tf-set-srid g c2))))
+   (let [g (.copy g)]
+     (.apply g (transform-coord-seq-filter (crs/create-transform c1 c2)))
+     (set-srid g (crs/get-srid c2)))))
 
-(defn ^Geometry transform-geom
-  "Transform a Geometry using a proj4j transform, if needed. Returns a new Geometry if a transform occurs.
-  When only one CRS is given, get the CRS of the existing geometry.
-  When two are given, force the transformation to occur between those two systems."
-  ([^Geometry g transform]
-   (cond (instance? CoordinateTransform transform)
-         ;; If transform is a transformation, apply that directly.
-         (tf (.copy g) transform)
-         :else
-         ;; Otherwise, assume that the argument is a destination CRS identifier.
+(defn transform-geom
+  ([g t]
+   (cond (instance? CoordinateTransform t)
+         (tf g t)
+         (satisfies? Transformable t)
          (let [geom-srid (get-srid g)]
            (assert (not= 0 geom-srid) "Geometry must have a valid SRID to be transformed")
-           (if (or (= geom-srid transform) (= (crs/srid->epsg-str geom-srid) transform))
+           (if (= (crs/get-srid t) geom-srid)
              g
-             (transform-geom g geom-srid transform)))))
-  ([^Geometry g crs1 crs2]
-   (if (= crs1 crs2)
-     (tf-set-srid g crs2)
-     (tf (.copy g) crs1 crs2))))
+             (tf g geom-srid t)))))
+  ([g c1 c2]
+   (tf g c1 c2)))
 
 (defn ^Point centroid
   "Get the centroid of a JTS object."

--- a/src/geo/jts.clj
+++ b/src/geo/jts.clj
@@ -268,13 +268,12 @@
   When the target transformation can be identified with an EPSG code, set the Geometry's SRID to that integer.
   When only a single CoordinateTransform is passed, set the SRID to 0."
   ([^Geometry g ^CoordinateTransform transform]
-   (let [g (.copy g)]
+   (let [g (.copy g)
+         target-srid (crs/get-srid (crs/get-target-crs transform))]
      (.apply g (transform-coord-seq-filter transform))
-     (set-srid g 0)))
+     (set-srid g target-srid)))
   ([^Geometry g c1 c2]
-   (let [g (.copy g)]
-     (.apply g (transform-coord-seq-filter (crs/create-transform c1 c2)))
-     (set-srid g (crs/get-srid c2)))))
+   (tf g (crs/create-transform c1 c2))))
 
 (defn transform-geom
   ([g t]

--- a/src/geo/jts.clj
+++ b/src/geo/jts.clj
@@ -263,18 +263,19 @@
       true)))
 
 (defn- tf
-  "Transform a Geometry.
-  When a single CoordinateTransform is passed, apply that transform to the Geometry. When the target CRS
-  has an SRID, set the geometry's SRID to that.
-  When two CRSs are passed as arguments, generate an appropriate CoordinateTransform and apply accordingly."
-  ([^Geometry g ^CoordinateTransform transform]
-   (let [g (.copy g)]
-     (.apply g (transform-coord-seq-filter transform))
-     (set-srid g (crs/get-srid (crs/get-target-crs transform)))))
-  ([^Geometry g c1 c2]
-   (tf g (crs/create-transform c1 c2))))
+  "Transform a Geometry by applying CoordinateTransform to the Geometry.
+  When the target CRS has an SRID, set the geometry's SRID to that."
+  [^Geometry g ^CoordinateTransform transform]
+  (let [g (.copy g)]
+    (.apply g (transform-coord-seq-filter transform))
+    (set-srid g (crs/get-srid (crs/get-target-crs transform)))))
 
 (defn transform-geom
+  "Transform a Geometry.
+  When a single CoordinateTransform is passed, apply that transform to the Geometry. When the target CRS
+  has an SRID, set the geometry's SRID to that. When a single Transformable target is passed, attempt to
+  find the geometry's CRS to generate and apply a CoordinateTransform. When two CRSs are passed as
+  arguments, generate a CoordinateTransform and apply accordingly."
   ([g t]
    (cond (instance? CoordinateTransform t)
          (tf g t)
@@ -285,7 +286,7 @@
              g
              (transform-geom g geom-srid t)))))
   ([g c1 c2]
-   (tf g c1 c2)))
+   (transform-geom g (crs/create-transform c1 c2))))
 
 (defn ^Point centroid
   "Get the centroid of a JTS object."

--- a/test/geo/t_crs.clj
+++ b/test/geo/t_crs.clj
@@ -25,13 +25,17 @@
                    src (sut/get-source-crs transform)
                    target (sut/get-target-crs transform)]
                (sut/get-name src) => "EPSG:4326"
-               (sut/get-name target) => "EPSG:2000"))
+               (sut/get-srid (sut/get-name src)) => 4326
+               (sut/get-name target) => "EPSG:2000"
+               (sut/get-srid (sut/get-name target)) => 2000))
        (fact "Creating transform from CRS Strings"
              (let [transform (sut/create-transform "ESRI:37211" "ESRI:37220")
                    src (sut/get-source-crs transform)
                    target (sut/get-target-crs transform)]
                (sut/get-name src) => "ESRI:37211"
-               (sut/get-name target) => "ESRI:37220"))
+               (sut/get-srid (sut/get-name src)) => 0
+               (sut/get-name target) => "ESRI:37220"
+               (sut/get-srid (sut/get-name target)) => 0))
        (fact "Creating transform from proj4 parameter strings"
              (let [transform (sut/create-transform "+proj=longlat +a=6378270 +b=6356794.343434343 +no_defs"
                                                    "+proj=longlat +a=6376896 +b=6355834.846687363 +no_defs")

--- a/test/geo/t_crs.clj
+++ b/test/geo/t_crs.clj
@@ -22,22 +22,22 @@
 (facts "Creating transformations"
        (fact "Creating transform from SRID ints"
              (let [transform (sut/create-transform 4326 2000)
-                   src (.getSourceCRS transform)
-                   target (.getTargetCRS transform)]
-               (.getName src) => "EPSG:4326"
-               (.getName target) => "EPSG:2000"))
+                   src (sut/get-source-crs transform)
+                   target (sut/get-target-crs transform)]
+               (sut/get-name src) => "EPSG:4326"
+               (sut/get-name target) => "EPSG:2000"))
        (fact "Creating transform from CRS Strings"
              (let [transform (sut/create-transform "ESRI:37211" "ESRI:37220")
-                   src (.getSourceCRS transform)
-                   target (.getTargetCRS transform)]
-               (.getName src) => "ESRI:37211"
-               (.getName target) => "ESRI:37220"))
+                   src (sut/get-source-crs transform)
+                   target (sut/get-target-crs transform)]
+               (sut/get-name src) => "ESRI:37211"
+               (sut/get-name target) => "ESRI:37220"))
        (fact "Creating transform from proj4 parameter strings"
              (let [transform (sut/create-transform "+proj=longlat +a=6378270 +b=6356794.343434343 +no_defs"
                                                    "+proj=longlat +a=6376896 +b=6355834.846687363 +no_defs")
-                   src (.getSourceCRS transform)
-                   target (.getTargetCRS transform)]
+                   src (sut/get-source-crs transform)
+                   target (sut/get-target-crs transform)]
                (into [] (.getParameters src)) => ["+proj=longlat" "+a=6378270" "+b=6356794.343434343" "+no_defs"]
                (into [] (.getParameters target)) => ["+proj=longlat" "+a=6376896" "+b=6355834.846687363" "+no_defs"]
-               (.getName src) => ""
-               (.getName target) => "")))
+               (sut/get-name src) => ""
+               (sut/get-name target) => "")))

--- a/test/geo/t_jts.clj
+++ b/test/geo/t_jts.clj
@@ -162,6 +162,12 @@
                                (set-srid 23031))
                            p2)
                => truthy))
+       (fact "crs/set-srid can take any Transformable"
+             (let [p1 (point 10 10 0)]
+               (get-srid (set-srid p1 (crs/create-crs 23031)))
+               => 23031
+               (get-srid (set-srid p1 (crs/create-crs "EPSG:23031")))
+               => 23031))
        (fact "CRS systems with different names"
              (let [p1 (point 42.3601 -71.0589)
                    p2 (transform-geom p1 26986)]

--- a/test/geo/t_jts.clj
+++ b/test/geo/t_jts.clj
@@ -1,5 +1,6 @@
 (ns geo.t-jts
   (:require [geo.jts :refer :all]
+            [geo.crs :as crs]
             [geo.geohash :as geohash]
             [geo.spatial :as spatial]
             [midje.sweet :refer [fact facts throws roughly truthy]])
@@ -135,6 +136,10 @@
                (transform-geom (point 10 10 0) 4326 4326)
                (point 10 10 4326))
              => truthy)
+       (fact "geometry: projection can happen using an external transform object, though SRID will be set to 0."
+             (same-geom?
+               (transform-geom (point 3.8142776 51.285914 4326) (crs/create-transform 4326 23031))
+               (set-srid (point 556878.9016076007 5682145.166264554 23031) 0)))
        (fact "An EPSG can be specified as an int or as an 'EPSG:XXXX' string. as an equivalent proj4 string"
              (let [p1 (point 3.8142776 51.285914 4326)
                    p2 (point 556878.9016076007 5682145.166264554 23031)]

--- a/test/geo/t_jts.clj
+++ b/test/geo/t_jts.clj
@@ -136,10 +136,11 @@
                (transform-geom (point 10 10 0) 4326 4326)
                (point 10 10 4326))
              => truthy)
-       (fact "geometry: projection can happen using an external transform object, though SRID will be set to 0."
+       (fact "geometry: projection can happen using an external transform object, though SRID may be set to 0 if it cannot be determined."
              (same-geom?
                (transform-geom (point 3.8142776 51.285914 4326) (crs/create-transform 4326 23031))
-               (set-srid (point 556878.9016076007 5682145.166264554 23031) 0)))
+               (point 556878.9016076007 5682145.166264554 23031))
+             => truthy)
        (fact "An EPSG can be specified as a number, an 'EPSG:XXXX' string, as an equivalent proj4 string,
               or a proj4j CRS object."
              (let [p1 (point 3.8142776 51.285914 4326)

--- a/test/geo/t_jts.clj
+++ b/test/geo/t_jts.clj
@@ -140,13 +140,20 @@
              (same-geom?
                (transform-geom (point 3.8142776 51.285914 4326) (crs/create-transform 4326 23031))
                (set-srid (point 556878.9016076007 5682145.166264554 23031) 0)))
-       (fact "An EPSG can be specified as an int or as an 'EPSG:XXXX' string. as an equivalent proj4 string"
+       (fact "An EPSG can be specified as a number, an 'EPSG:XXXX' string, as an equivalent proj4 string,
+              or a proj4j CRS object."
              (let [p1 (point 3.8142776 51.285914 4326)
                    p2 (point 556878.9016076007 5682145.166264554 23031)]
                (same-geom? (transform-geom p1 23031) p2)
                => truthy
                (same-geom? (transform-geom p1 "EPSG:23031") p2)
-               => truthy))
+               => truthy
+               (get-srid (transform-geom p1 23031))
+               => 23031
+               (get-srid (transform-geom p1 "EPSG:23031"))
+               => 23031
+               (get-srid (transform-geom p1 (crs/create-crs 23031)))
+               => 23031))
        (fact "If using a different CRS name or proj4 string, SRID is not automatically set"
              (let [p1 (point 3.8142776 51.285914 4326)
                    p2 (point 556878.9016076007 5682145.166264554 23031)]


### PR DESCRIPTION
Current functionality of `transform-geom` either allows for 1) providing a single target CRS or 2) forcing a transformation between two CRSs, but either way this invokes the creation of a CoordinateTransform every time, which is (by far) the most computationally expensive operation. In cases where there's a bunch of geometries to be transformed in the exact same way (all the objects coming out of a shapefile or other geojson, for example), it'd be much more efficient to be able to pass a single transformation and apply that one transform to each. This PR changes `transform-geom`'s two-argument arity to work with either a target CRS or a CoordinateTransform.

Creating a single transform takes multiple milliseconds.
```clojure
(bench
  (crs/create-transform 4326 23031))
Evaluation count : 8640 in 60 samples of 144 calls.
             Execution time mean : 7.293338 ms
    Execution time std-deviation : 179.947793 µs
   Execution time lower quantile : 7.018824 ms ( 2.5%)
   Execution time upper quantile : 7.565371 ms (97.5%)
                   Overhead used : 9.212071 ns

Found 1 outliers in 60 samples (1.6667 %)
	low-severe	 1 (1.6667 %)
 Variance from outliers : 12.5728 % Variance is moderately inflated by outliers
```

Applying an existing transform to one point takes less than 1 microsecond:
```clojure
(let [t (crs/create-transform 4326 23031)]
  (bench (transform-geom (point 3.8142776 51.285914) t)))
Evaluation count : 125519880 in 60 samples of 2091998 calls.
             Execution time mean : 479.327737 ns
    Execution time std-deviation : 11.537641 ns
   Execution time lower quantile : 464.750123 ns ( 2.5%)
   Execution time upper quantile : 492.211072 ns (97.5%)
                   Overhead used : 9.212071 ns

Found 1 outliers in 60 samples (1.6667 %)
	low-severe	 1 (1.6667 %)
 Variance from outliers : 11.0549 % Variance is moderately inflated by outliers
```

Applying an existing transform to a multipolygon with multiple coordinates, still takes something on the order of 1 microsecond per coordinate:
```clojure
(let [t (crs/create-transform 4326 23031)]
  (bench (transform-geom (multi-polygon-wkt [[[10 10, 80 10, 80 80, 10 80, 10 10],
                                              [20 20, 20 30, 30 30, 30 20, 20 20],
                                              [40 20, 40 30, 50 30, 50 20, 40 20]]]) t)))
Evaluation count : 2888040 in 60 samples of 48134 calls.
             Execution time mean : 21.402541 µs
    Execution time std-deviation : 587.682842 ns
   Execution time lower quantile : 20.578319 µs ( 2.5%)
   Execution time upper quantile : 22.384869 µs (97.5%)
                   Overhead used : 9.212071 ns

Found 1 outliers in 60 samples (1.6667 %)
	low-severe	 1 (1.6667 %)
 Variance from outliers : 14.2229 % Variance is moderately inflated by outliers
```