### PR TITLE
Switch proj4j to locationtech release

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ We unify five open-source JVM geospatial libraries: The [JTS topology
 suite](https://github.com/locationtech/jts),
 [spatial4j](https://github.com/spatial4j/spatial4j),
 [geohash-java](https://github.com/kungfoo/geohash-java),
-[proj4j](https://github.com/locationtech/geotrellis/tree/master/proj4),
+[proj4j](https://github.com/locationtech/proj4j),
 and [h3](https://github.com/uber/h3-java). Clojure
 protocols allow these libraries' disparate representations of points, shapes,
 and spatial reference systems to interoperate, so you can, for instance, ask

--- a/project.clj
+++ b/project.clj
@@ -10,7 +10,7 @@
   [[org.clojure/math.numeric-tower "0.0.4"]
    [ch.hsr/geohash "1.3.0"]
    [com.uber/h3 "3.2.0"]
-   [org.locationtech.geotrellis/geotrellis-proj4_2.11 "2.1.0"]
+   [org.locationtech.proj4j/proj4j "0.2.0"]
    [org.locationtech.spatial4j/spatial4j "0.7"]
    [org.locationtech.jts/jts-core "1.16.0"]
    [org.locationtech.jts.io/jts-io-common "1.16.0"]

--- a/project.clj
+++ b/project.clj
@@ -10,7 +10,7 @@
   [[org.clojure/math.numeric-tower "0.0.4"]
    [ch.hsr/geohash "1.3.0"]
    [com.uber/h3 "3.2.0"]
-   [org.locationtech.proj4j/proj4j "0.2.0"]
+   [org.locationtech.proj4j/proj4j "1.0.0"]
    [org.locationtech.spatial4j/spatial4j "0.7"]
    [org.locationtech.jts/jts-core "1.16.0"]
    [org.locationtech.jts.io/jts-io-common "1.16.0"]

--- a/src/geo/crs.clj
+++ b/src/geo/crs.clj
@@ -1,8 +1,8 @@
 (ns geo.crs
   "Helper functions for identifying and manipulating Coordinate Reference Systems."
-  (:import (org.osgeo.proj4j CoordinateTransform
-                             CoordinateTransformFactory
-                             CRSFactory)))
+  (:import (org.locationtech.proj4j CoordinateTransform
+                                    CoordinateTransformFactory
+                                    CRSFactory)))
 
 (defn starts-with? [^String string prefix]
   (.startsWith string prefix))

--- a/src/geo/crs.clj
+++ b/src/geo/crs.clj
@@ -43,9 +43,6 @@
   [crs-str]
   (includes? crs-str "+proj="))
 
-;; Maintain old proj4-string? function name until at least version 3.0, but deprecate.
-(def proj4-string? proj4-str?)
-
 (defn- create-crs-int
   [^Integer c]
   (.createFromName crs-factory (srid->epsg-str c)))

--- a/src/geo/jts.clj
+++ b/src/geo/jts.clj
@@ -17,7 +17,7 @@
                                       MultiPolygon
                                       Polygon
                                       PrecisionModel)
-           (org.osgeo.proj4j CoordinateTransform ProjCoordinate)))
+           (org.locationtech.proj4j CoordinateTransform ProjCoordinate)))
 
 (def ^PrecisionModel pm (PrecisionModel. PrecisionModel/FLOATING))
 

--- a/test/geo/t_crs.clj
+++ b/test/geo/t_crs.clj
@@ -15,8 +15,6 @@
                   (every? sut/crs-name?)) => true)
        (fact "+proj=merc +lat_ts=56.5 +ellps=GRS80" => sut/proj4-str?)
        (fact "pizza" => (comp not sut/proj4-str?))
-       ; Maintain alias of proj4-str? until at least version 3.0
-       (fact "+proj=merc +lat_ts=56.5 +ellps=GRS80" => sut/proj4-string?)
        (fact (sut/epsg-str->srid "EPSG:4326") => 4326)
        (fact (sut/epsg-str->srid "pizza") => (m/throws AssertionError))
        (fact (sut/epsg-str->srid "EPSG:4326.0") => (m/throws AssertionError)))


### PR DESCRIPTION
Locationtech's [proj4j](https://github.com/locationtech/proj4j) is now officially released as 0.2.0, so we can use that as the upstream projection dependency. In addition to its ongoing bugfixes, this also means that we can shed all of the extraneous scala and other dependencies that came with geotrellis's fork (this 0.2.0 release is based off of that fork). The downside is that this means that `create-transform` in the `crs` namespace now has a different group ID, which technically means that this would be a major version breaking change like 2.0.