### PR TITLE
H3 update

### DIFF
--- a/project.clj
+++ b/project.clj
@@ -9,22 +9,22 @@
   :dependencies
   [[org.clojure/math.numeric-tower "0.0.4"]
    [ch.hsr/geohash "1.3.0"]
-   [com.uber/h3 "3.2.0"]
+   [com.uber/h3 "3.4.0"]
    [org.locationtech.proj4j/proj4j "1.0.0"]
    [org.locationtech.spatial4j/spatial4j "0.7"]
-   [org.locationtech.jts/jts-core "1.16.0"]
-   [org.locationtech.jts.io/jts-io-common "1.16.0"]
+   [org.locationtech.jts/jts-core "1.16.1"]
+   [org.locationtech.jts.io/jts-io-common "1.16.1"]
    [org.noggit/noggit "0.8"]
    [org.wololo/jts2geojson "0.13.0"]]
   :codox {:themes [:rdash]}
   :profiles {:dev {:global-vars {*warn-on-reflection* true}
                    :plugins [[lein-midje "3.2.1"]
-                             [lein-codox "0.10.5"]]
+                             [lein-codox "0.10.6"]]
                    :dependencies [[org.clojure/clojure "1.10.0"]
                                   [codox-theme-rdash "0.1.2"]
                                   [criterium "0.4.4"]
                                   [cheshire "5.8.1"]
-                                  [midje "1.9.5"]]}
+                                  [midje "1.9.6"]]}
              :1.9 {:dependencies [[org.clojure/clojure "1.9.0"]]}
              :1.8 {:dependencies [[org.clojure/clojure "1.8.0"]]}
              :1.7 {:dependencies [[org.clojure/clojure "1.7.0"]]}})

--- a/src/geo/h3.clj
+++ b/src/geo/h3.clj
@@ -187,6 +187,16 @@
   [^Long c1 ^Long c2]
   (.h3Distance h3-inst c1 c2))
 
+(defn- h3-line-string
+  "String helper to return the line of indexes between cells"
+  [^String c1 ^String c2]
+  (.h3Line h3-inst c1 c2))
+
+(defn- h3-line-long
+  "Long helper to return the line of indexes between cells"
+  [^Long c1 ^Long c2]
+  (.h3Line h3-inst c1 c2))
+
 (defprotocol H3Index
   (to-string [this] "Return index as a string.")
   (to-long [this] "Return index as a long.")
@@ -203,7 +213,8 @@
   (pentagon? [this] "Check if an index is a pentagon.")
   (is-valid? [this] "Check if an index is valid.")
   (neighbors? [this cell] "Check if two indexes are neighbors.")
-  (h3-distance [this cell] "Return the grid distance, which is the distance expressed in number of cells."))
+  (h3-distance [this cell] "Return the grid distance, which is the distance expressed in number of cells.")
+  (h3-line [this cell] "Return the line of indexes between two cells"))
 
 (extend-protocol H3Index
   String
@@ -223,6 +234,7 @@
   (is-valid? [this] (is-valid?-string this))
   (neighbors? [this cell] (neighbors?-string this cell))
   (h3-distance [this cell] (h3-distance-string this cell))
+  (h3-line [this cell] (h3-line-string this cell))
 
   Long
   (to-string [this] (long->string this))
@@ -240,7 +252,8 @@
   (pentagon? [this] (pentagon?-long this))
   (is-valid? [this] (is-valid?-long this))
   (neighbors? [this cell] (neighbors?-long this cell))
-  (h3-distance [this cell] (h3-distance-long this cell)))
+  (h3-distance [this cell] (h3-distance-long this cell))
+  (h3-line [this cell] (h3-line-long this cell)))
 
 (defprotocol Polygonal
   (to-polygon [this] [this srid] "Ensure that an object is 2D, with lineal boundaries.")
@@ -540,3 +553,8 @@
         (multi-polygon-n cells)
         (string? (first cells))
         (multi-polygon-s cells)))
+
+(defn get-res-0-indexes
+  "Return a collection of all base cells"
+  []
+  (.getRes0Indexes h3-inst))

--- a/test/geo/t_h3.clj
+++ b/test/geo/t_h3.clj
@@ -66,8 +66,59 @@
              (sut/h3-distance "85283083fffffff" "85283473fffffff") => 4
              (sut/h3-distance 599685771850416127 599686042433355775) => 4
              (sut/h3-distance "85283083fffffff" "85283447fffffff") => 5
-             (sut/h3-distance 599685771850416127 599686030622195711) => 5))
+             (sut/h3-distance 599685771850416127 599686030622195711) => 5)
+       (fact "get resolution 0 indexes"
+             (count (sut/get-res-0-indexes)) => 122))
 
+(facts "line checks"
+       (let [p1 (jts/point 37.5 -122)
+             p2 (jts/point 25 -120)
+             c1 (fn [res] (sut/pt->h3 p1 res))
+             c2 (fn [res] (sut/pt->h3 p2 res))
+             line (fn [res] (sut/h3-line (c1 res) (c2 res)))
+             distance (fn [res] (sut/h3-distance (c1 res) (c2 res)))]
+         (facts "resolution 0"
+                (fact "distance matches expected"
+                      (count (line 0)) => (inc (distance 0)))
+                (fact "line contains start"
+                      (some #{(c1 0)} (line 0)) => truthy)
+                (fact "line contains end"
+                      (some #{(c2 0)} (line 0)) => truthy))
+         (facts "resolution 1"
+                (fact "distance matches expected"
+                      (count (line 1)) => (inc (distance 1)))
+                (fact "line contains start"
+                      (some #{(c1 1)} (line 1)) => truthy)
+                (fact "line contains end"
+                      (some #{(c2 1)} (line 1)) => truthy))
+         (facts "resolution 2"
+                (fact "distance matches expected"
+                      (count (line 2)) => (inc (distance 2)))
+                (fact "line contains start"
+                      (some #{(c1 2)} (line 2)) => truthy)
+                (fact "line contains end"
+                      (some #{(c2 2)} (line 2)) => truthy))
+         (facts "resolution 10"
+                (fact "distance matches expected"
+                      (count (line 10)) => (inc (distance 10)))
+                (fact "line contains start"
+                      (some #{(c1 10)} (line 10)) => truthy)
+                (fact "line contains end"
+                      (some #{(c2 10)} (line 10)) => truthy))
+         (facts "resolution 11"
+                (fact "distance matches expected"
+                      (count (line 11)) => (inc (distance 11)))
+                (fact "line contains start"
+                      (some #{(c1 11)} (line 11)) => truthy)
+                (fact "line contains end"
+                      (some #{(c2 11)} (line 11)) => truthy))
+         (facts "resolution 12"
+                (fact "distance matches expected"
+                      (count (line 12)) => (inc (distance 12)))
+                (fact "line contains start"
+                      (some #{(c1 12)} (line 12)) => truthy)
+                (fact "line contains end"
+                      (some #{(c2 12)} (line 12)) => truthy))))
 
 (facts "h3 algorithms"
        (fact "rings"


### PR DESCRIPTION
This bumps h3 to 3.4.0 and adds wrappers for its new `h3-line` and `get-res-0-indexes` functions.