### PR TITLE
Add Feature record, with :geometry and :properties

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@
 * `geo.io` readers and writers are now thread-safe
 * Add `h3-line` function to H3 protocol, which returns the line of indexes between two cells
 * Add `get-res-0-indexes` function for H3, which returns a collection of all indexes at resolution 0
+* Add a `Feature` record type to `geo.spatial`, codifying the idea that a feature contains `:geometry` and `:properties`
 * Add testing support for JDK11 and Clojure 1.10
 * Bump `h3` to 3.4.0, enabling support for functions described above
 * Bump other core dependencies to keep up with upstream changes: `jts2geojson` to 0.13.0, and `jts` to 1.16.1

--- a/src/geo/spatial.clj
+++ b/src/geo/spatial.clj
@@ -177,6 +177,8 @@
   (to-geohash-point [this] (geohash-point this))
   (to-h3-point [this] this))
 
+(defrecord Feature [geometry properties])
+
 (defn degrees->radians
   [degrees]
   (DistanceUtils/toRadians degrees))

--- a/test/geo/t_io.clj
+++ b/test/geo/t_io.clj
@@ -100,11 +100,11 @@
 (fact "Reading GeoJSON Geometry"
       (count (sut/read-geojson geometry)) => 1
       (let [parsed (first (sut/read-geojson geometry))]
-        parsed => map?
-        (keys parsed) => [:properties :geometry]
+        (type parsed) => geo.spatial.Feature
+        (keys parsed) => [:geometry :properties]
         (-> parsed :geometry .getNumPoints) => 5
         (->> parsed :geometry .getCoordinates (map (fn [c] [(.x c) (.y c)]))) => coords
-        (-> parsed :geometry sut/to-geojson sut/read-geojson parsed)))
+        (-> parsed :geometry sut/to-geojson sut/read-geojson first) => parsed))
 
 (fact "Reading GeoJSON Feature"
       (count (sut/read-geojson feature)) => 1

--- a/test/geo/t_spatial.clj
+++ b/test/geo/t_spatial.clj
@@ -232,7 +232,7 @@
 
            (fact "Accepts custom distribution function"
                  (let [distrib (fn [] 1)
-                       points (take 20 )]
+                       points (take 20)]
                    (->> (partial s/rand-point-in-radius 0 0 100 distrib)
                         (repeatedly)
                         (take 20)
@@ -270,4 +270,7 @@
                (:geometry f2) => g1)
          (fact "feature record has a properties field"
                (:properties f1) => p1
-               (:properties f2) => p1)))
+               (:properties f2) => p1)
+         (fact "features generated from maps retain additional fields"
+               (:additional f2) => "information"
+               (:additional f1) => nil)))

--- a/test/geo/t_spatial.clj
+++ b/test/geo/t_spatial.clj
@@ -254,3 +254,20 @@
                         (map dist)
                         (filter (partial > 50))
                         count) => (roughly 250 10))))))
+
+(facts "features"
+       (let [g1 (s/jts-point 0 0)
+             p1 {:name "null"}
+             f1 (s/->Feature g1 p1)
+             f2 (s/map->Feature {:geometry g1
+                                 :properties p1
+                                 :additional "information"})]
+         (fact "feature record is recognized"
+               (type f1) => geo.spatial.Feature
+               (type f2) => geo.spatial.Feature)
+         (fact "feature record has a geometry field"
+               (:geometry f1) => g1
+               (:geometry f2) => g1)
+         (fact "feature record has a properties field"
+               (:properties f1) => p1
+               (:properties f2) => p1)))


### PR DESCRIPTION
The ad-hoc `feature-map` argument we added to `geo.io` never quite felt finished to me and has been a place where it's been easy for me to slip up and pass incorrectly defined maps to the functions. It seems like a perfect case for a clojure record, where we know the map will always need to have a geometry and properties field. @worace 