### PR TITLE
Add support for JTS MultiPoint and MultiLineString [Wrong origin]

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@
 * `geo.io` readers and writers are now thread-safe
 * Add `h3-line` function to H3 protocol, which returns the line of indexes between two cells
 * Add `get-res-0-indexes` function for H3, which returns a collection of all indexes at resolution 0
+* Add `multi-point`, `multi-linestring`, and `multi-linestring-wkt` functions to `geo.jts`
 * Add testing support for JDK11 and Clojure 1.10
 * Bump `h3` to 3.4.0, enabling support for functions described above
 * Bump other core dependencies to keep up with upstream changes: `jts2geojson` to 0.13.0, and `jts` to 1.16.1

--- a/src/geo/jts.clj
+++ b/src/geo/jts.clj
@@ -67,6 +67,10 @@
   [coordinates]
   (into-array Coordinate coordinates))
 
+(defn ^"[Lorg.locationtech.jts.geom.Point;" point-array
+  [points]
+  (into-array Point points))
+
 (defn ^"[Lorg.locationtech.jts.geom.Geometry;" geom-array
   [geoms]
   (into-array Geometry geoms))
@@ -75,9 +79,22 @@
   [rings]
   (into-array LinearRing rings))
 
+(defn ^"[Lorg.locationtech.jts.geom.LineString;" linestring-array
+  [linestrings]
+  (into-array LineString linestrings))
+
 (defn ^"[Lorg.locationtech.jts.geom.Polygon;" polygon-array
   [polygons]
   (into-array Polygon polygons))
+
+(defn multi-point
+  "Given a list of points, generates a MultiPoint."
+  [points]
+  (let [f (first points)
+        srid (get-srid f)]
+    (-> (.createMultiPoint (get-factory f)
+                           (point-array points))
+        (set-srid srid))))
 
 (defn ^CoordinateSequence coordinate-sequence
   "Given a list of Coordinates, generates a CoordinateSequence."
@@ -115,6 +132,15 @@
   ([coordinates srid]
    (.createLineString (gf srid) (coord-array coordinates))))
 
+(defn multi-linestring
+  "Given a list of LineStrings, generates a MultiLineString."
+  [linestrings]
+  (let [f (first linestrings)
+        srid (get-srid f)]
+    (-> (.createMultiLineString (get-factory f)
+                                (linestring-array linestrings))
+        (set-srid srid))))
+
 (defn linestring-wkt
   "Makes a LineString from a WKT-style data structure: a flat sequence of
   coordinate pairs, e.g. [0 0, 1 0, 0 2, 0 0]. Allows an optional SRID argument at end."
@@ -122,6 +148,14 @@
    (-> coordinates wkt->coords-array linestring))
   ([coordinates srid]
    (-> coordinates wkt->coords-array (linestring srid))))
+
+(defn multi-linestring-wkt
+  "Creates a MultiLineString from a WKT-style data structure, e.g. [[0 0, 1 0, 0 2, 0 0] [0 -1 1 2]].
+  Allows an optional SRID argument at end."
+  ([wkt]
+   (multi-linestring (map linestring-wkt wkt)))
+  ([wkt srid]
+   (multi-linestring (map #(linestring-wkt % srid) wkt))))
 
 (defn coords
   [^LineString linestring]

--- a/test/geo/t_jts.clj
+++ b/test/geo/t_jts.clj
@@ -24,6 +24,10 @@
              (.getZ (coordinate 1 2 3 4)) => 3.0
              (.getM (coordinate 1 2 3 4)) => 4.0))
 
+(facts "multi-point"
+       (fact (str (multi-point [(point 0 0) (point 1 1)]))
+             => "MULTIPOINT ((0 0), (1 1))"))
+
 (facts "coordinate sequence"
        (fact "XY/XYZ coordinate sequence"
              (.getDimension (coordinate-sequence [(coordinate 1 1) (coordinate 2 2)])) => 3
@@ -88,6 +92,16 @@
          (-> segment .p0 .y) => -1.0
          (-> segment .p1 .x) => 1.0
          (-> segment .p1 .y) => 2.0))
+
+(facts "multi-linestrings"
+       (fact (str (multi-linestring
+                    [(linestring [(coordinate 0 0) (coordinate 1 1)])
+                     (linestring [(coordinate 2 2) (coordinate 3 3)])]))
+             => "MULTILINESTRING ((0 0, 1 1), (2 2, 3 3))"))
+
+(facts "multi-linestring-wkt"
+       (fact (str (multi-linestring-wkt [[0 0, 1 0, 0 2, 0 0] [0 -1 1 2]]))
+             => "MULTILINESTRING ((0 0, 1 0, 0 2, 0 0), (0 -1, 1 2))"))
 
 (facts "Comparing geometry SRIDs"
        (let [g1 (linestring-wkt [0 0 0 1 0 2])


### PR DESCRIPTION
Adding `multi-point` and `multi-linestring` to go with the existing `multi-polygon` in `geo.jts`. @worace 