### PR TITLE
Add support for JTS MultiPoint and MultiLineString

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@
 * `geo.io` readers and writers are now thread-safe
 * Add `h3-line` function to H3 protocol, which returns the line of indexes between two cells
 * Add `get-res-0-indexes` function for H3, which returns a collection of all indexes at resolution 0
+* Add `multi-point`, `multi-linestring`, and `multi-linestring-wkt` functions to `geo.jts`
 * Add testing support for JDK11 and Clojure 1.10
 * Bump `h3` to 3.4.0, enabling support for functions described above
 * Bump other core dependencies to keep up with upstream changes: `jts2geojson` to 0.13.0, and `jts` to 1.16.1

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@
 * Add `get-res-0-indexes` function for H3, which returns a collection of all indexes at resolution 0
 * Add `multi-point`, `multi-linestring`, and `multi-linestring-wkt` functions to `geo.jts`
 * Add testing support for JDK11 and Clojure 1.10
+* Fix reflection on geometry creation functions in the `jts` namespace
 * Bump `h3` to 3.4.0, enabling support for functions described above
 * Bump other core dependencies to keep up with upstream changes: `jts2geojson` to 0.13.0, and `jts` to 1.16.1
 * Bump internal dependencies for testing and documentation: `midje` to 1.9.6, `cheshire` to 5.8.1, and `lein-codox` to 0.10.6

--- a/src/geo/io.clj
+++ b/src/geo/io.clj
@@ -52,7 +52,7 @@
   (WKBWriter/toHex (to-wkb (to-jts shapelike))))
 
 (defn to-ewkb-hex
-  "Write an EWKB as a hex string, excluding any SRID"
+  "Write an EWKB as a hex string, including any SRID"
   [shapelike]
   (WKBWriter/toHex (to-ewkb (to-jts shapelike))))
 

--- a/src/geo/jts.clj
+++ b/src/geo/jts.clj
@@ -14,6 +14,8 @@
                                       LinearRing
                                       LineSegment
                                       LineString
+                                      MultiPoint
+                                      MultiLineString
                                       MultiPolygon
                                       Polygon
                                       PrecisionModel)
@@ -54,7 +56,7 @@
   ([^double x ^double y ^double z ^double m]
    (CoordinateXYZM. x y z m)))
 
-(defn point
+(defn ^Point point
   "Creates a Point from a Coordinate, a lat/long, or an x,y pair with an SRID."
   ([^Coordinate coordinate]
    (.createPoint gf-wgs84 coordinate))
@@ -87,7 +89,7 @@
   [polygons]
   (into-array Polygon polygons))
 
-(defn multi-point
+(defn ^MultiPoint multi-point
   "Given a list of points, generates a MultiPoint."
   [points]
   (let [f (first points)
@@ -125,14 +127,14 @@
        (partition 2)
        (map (partial apply coordinate))))
 
-(defn linestring
+(defn ^LineString linestring
   "Given a list of Coordinates, creates a LineString. Allows an optional SRID argument at end."
   ([coordinates]
    (.createLineString gf-wgs84 (coord-array coordinates)))
   ([coordinates srid]
    (.createLineString (gf srid) (coord-array coordinates))))
 
-(defn multi-linestring
+(defn ^MultiLineString multi-linestring
   "Given a list of LineStrings, generates a MultiLineString."
   [linestrings]
   (let [f (first linestrings)
@@ -215,7 +217,7 @@
    (let [rings (map #(linear-ring-wkt % srid) rings)]
      (polygon (first rings) (into-array LinearRing (rest rings))))))
 
-(defn multi-polygon
+(defn ^MultiPolygon multi-polygon
   "Given a list of polygons, generates a MultiPolygon."
   [polygons]
   (let [f (first polygons)

--- a/src/geo/jts.clj
+++ b/src/geo/jts.clj
@@ -67,6 +67,10 @@
   [coordinates]
   (into-array Coordinate coordinates))
 
+(defn ^"[Lorg.locationtech.jts.geom.Point;" point-array
+  [points]
+  (into-array Point points))
+
 (defn ^"[Lorg.locationtech.jts.geom.Geometry;" geom-array
   [geoms]
   (into-array Geometry geoms))
@@ -75,9 +79,22 @@
   [rings]
   (into-array LinearRing rings))
 
+(defn ^"[Lorg.locationtech.jts.geom.LineString;" linestring-array
+  [linestrings]
+  (into-array LineString linestrings))
+
 (defn ^"[Lorg.locationtech.jts.geom.Polygon;" polygon-array
   [polygons]
   (into-array Polygon polygons))
+
+(defn multi-point
+  "Given a list of points, generates a MultiPoint."
+  [points]
+  (let [f (first points)
+        srid (get-srid f)]
+    (-> (.createMultiPoint (get-factory f)
+                           (point-array points))
+        (set-srid srid))))
 
 (defn ^CoordinateSequence coordinate-sequence
   "Given a list of Coordinates, generates a CoordinateSequence."
@@ -115,6 +132,15 @@
   ([coordinates srid]
    (.createLineString (gf srid) (coord-array coordinates))))
 
+(defn multi-linestring
+  "Given a list of LineStrings, generates a MultiLineString."
+  [linestrings]
+  (let [f (first linestrings)
+        srid (get-srid f)]
+    (-> (.createMultiLineString (get-factory f)
+                                (linestring-array linestrings))
+        (set-srid srid))))
+
 (defn linestring-wkt
   "Makes a LineString from a WKT-style data structure: a flat sequence of
   coordinate pairs, e.g. [0 0, 1 0, 0 2, 0 0]. Allows an optional SRID argument at end."
@@ -122,6 +148,14 @@
    (-> coordinates wkt->coords-array linestring))
   ([coordinates srid]
    (-> coordinates wkt->coords-array (linestring srid))))
+
+(defn multi-linestring-wkt
+  "Creates a MultiLineString from a WKT-style data structure, e.g. [[0 0, 1 0, 0 2, 0 0] [0 -1 1 2]].
+  Allows an optional SRID argument at end."
+  ([wkt]
+   (multi-linestring (map linestring-wkt wkt)))
+  ([wkt srid]
+   (multi-linestring (map #(linestring-wkt % srid) wkt))))
 
 (defn coords
   [^LineString linestring]

--- a/test/geo/t_jts.clj
+++ b/test/geo/t_jts.clj
@@ -17,12 +17,18 @@
              (.getX (coordinate 1 2 3)) => 1.0
              (.getY (coordinate 1 2 3)) => 2.0
              (.getZ (coordinate 1 2 3)) => 3.0)
+       (fact "XYZ coordinates can still be pulled out from geometries that don't support higher dimensions"
+             (.getCoordinate (point (coordinate 1 2 3))) => (Coordinate. 1 2 3)
+             (.getCoordinateN (linestring [(coordinate 1 2 3) (coordinate 4 5 6)]) 0) => (Coordinate. 1 2 3))
        (fact "XYZM coordinate"
              (coordinate 1 2 3 4) => (CoordinateXYZM. 1 2 3 4)
              (.getX (coordinate 1 2 3 4)) => 1.0
              (.getY (coordinate 1 2 3 4)) => 2.0
              (.getZ (coordinate 1 2 3 4)) => 3.0
-             (.getM (coordinate 1 2 3 4)) => 4.0))
+             (.getM (coordinate 1 2 3 4)) => 4.0)
+       (fact "XYZM coordinates can still be pulled out from geometries that don't support higher dimensions"
+             (.getCoordinate (point (coordinate 1 2 3 4))) => (CoordinateXYZM. 1 2 3 4)
+             (.getCoordinateN (linestring [(coordinate 1 2 3 4) (coordinate 4 5 6 7)]) 0) => (CoordinateXYZM. 1 2 3 4)))
 
 (facts "multi-point"
        (fact (str (multi-point [(point 0 0) (point 1 1)]))

--- a/test/geo/t_jts.clj
+++ b/test/geo/t_jts.clj
@@ -24,6 +24,10 @@
              (.getZ (coordinate 1 2 3 4)) => 3.0
              (.getM (coordinate 1 2 3 4)) => 4.0))
 
+(facts "multi-point"
+       (fact (str (multi-point [(point 0 0) (point 1 1)]))
+             => "MULTIPOINT ((0 0), (1 1))"))
+
 (facts "coordinate sequence"
        (fact "XY/XYZ coordinate sequence"
              (.getDimension (coordinate-sequence [(coordinate 1 1) (coordinate 2 2)])) => 3
@@ -88,6 +92,16 @@
          (-> segment .p0 .y) => -1.0
          (-> segment .p1 .x) => 1.0
          (-> segment .p1 .y) => 2.0))
+
+(facts "multi-linestrings"
+       (fact (str (multi-linestring
+                    [(linestring [(coordinate 0 0) (coordinate 1 1)])
+                     (linestring [(coordinate 2 2) (coordinate 3 3)])]))
+             => "MULTILINESTRING ((0 0, 1 1), (2 2, 3 3))"))
+
+(facts "multi-linestring-wkt"
+       (fact (str (multi-linestring-wkt [[0 0, 1 0, 0 2, 0 0] [0 -1 1 2]]))
+             => "MULTILINESTRING ((0 0, 1 0, 0 2, 0 0), (0 -1, 1 2))"))
 
 (facts "Comparing geometry SRIDs"
        (let [g1 (linestring-wkt [0 0 0 1 0 2])


### PR DESCRIPTION
#53 was from my personal repository, which led to the build error. This also adds some reflection fixes which came up during these additions, as well as tests clarifying JTS's behavior around how XYZ or XYZM coordinates behave inside geometries that don't work on that many dimensions.