### PR TITLE
Add line-segment function to JTS

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,7 +8,7 @@
 * `geo.io` readers and writers are now thread-safe
 * Add `h3-line` function to H3 protocol, which returns the line of indexes between two cells
 * Add `get-res-0-indexes` function for H3, which returns a collection of all indexes at resolution 0
-* Add `multi-point`, `multi-linestring`, and `multi-linestring-wkt` functions to `geo.jts`
+* Add `line-segment`, `multi-point`, `multi-linestring`, and `multi-linestring-wkt` functions to `geo.jts`
 * Add testing support for JDK11, JDK12, JDK13, and Clojure 1.10
 * Fix reflection on geometry creation functions in the `jts` namespace
 * Bump `h3` to 3.4.1, enabling support for functions described above

--- a/src/geo/jts.clj
+++ b/src/geo/jts.clj
@@ -172,10 +172,15 @@
   [^LineString linestring idx]
   (.getPointN linestring idx))
 
+(defn line-segment
+  "Given two Coordinates, creates a LineSegment."
+  [^Coordinate c1 ^Coordinate c2]
+  (LineSegment. c1 c2))
+
 (defn segment-at-idx
   "LineSegment from a LineString's point at index to index + 1."
   [^LineString linestring idx]
-  (LineSegment. (coord (point-n linestring idx))
+  (line-segment (coord (point-n linestring idx))
                 (coord (point-n linestring (inc idx)))))
 
 (defn ^LinearRing linear-ring

--- a/test/geo/t_jts.clj
+++ b/test/geo/t_jts.clj
@@ -85,6 +85,14 @@
                                                                 (point 0 0 2229)]))))
              => 2229))
 
+(facts "line segments"
+       (let [c1 (coordinate 0 0)
+             c2 (coordinate 1 1)
+             ls (line-segment (coordinate 0 0) (coordinate 1 1))]
+         (fact (type ls) => org.locationtech.jts.geom.LineSegment)
+         (fact (.getCoordinate ls 0) => c1)
+         (fact (.getCoordinate ls 1) => c2)))
+
 (facts "linestrings"
        (.getNumPoints (linestring-wkt [0 0 0 1 0 2])) => 3
        (type (first (coords (linestring-wkt [0 0 0 1 0 2])))) => org.locationtech.jts.geom.Coordinate


### PR DESCRIPTION
`LineSegment` was already being imported and used in in the `jts` namespace, but there wasn't a constructor function for it yet. Some of the JTS algorithms take `LineSegment`s as arguments, so it's helpful to be able to make them directly.