### PR TITLE
Add testing for openj9, removing use of deprecated spatial4j functions

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -21,6 +21,7 @@ before_install:
   - cd /home/travis/bin
   - curl -O https://raw.githubusercontent.com/technomancy/leiningen/stable/bin/lein
   - chmod +x /home/travis/bin/lein
+  - cd /home/travis/Factual/geo
   - lein deps
 
 install:

--- a/.travis.yml
+++ b/.travis.yml
@@ -7,7 +7,6 @@ env:
   - secure: QYOLwEqrVn8dlT3qwznYXujR3x4ZE0WJcBeQoMVbofVMqwcC+xA4uOnfI1M0xQwzfYCD92mIUSoc0KGQGI7jCT2dcr2di2BEJZvIV4ra+CqgoHMJYd9S/hZCZuQWygX3MhBPl17jSKi2NQPAKu7tuP12Yd5GNBttiYOOyRFMdjY=
   - secure: Ny8wgc/tZqRR9/mv3vHupyKz1hvl7krMx+qCEILwsvgPZZg0fVTzZ+48HHzQ0CoNKY+u9PBHLuxPBkma5NM4NpdbsCySN6stqpIQJW7IwYvm6i2TkYHTD3BFv4MAkzxwON71Z1rUjCD3moh3TQGNVW+xNUv17UxUDB6KlK9BGS8=
   - JABBA_HOME: /home/travis/.jabba
-  - PATH: "/home/travis/bin:$PATH"
   matrix:
   - TRAVIS_JDK=amazon-corretto@1.8.222-10.1
   - TRAVIS_JDK=amazon-corretto@1.11.0-4.11.1
@@ -19,7 +18,6 @@ before_install:
   - openssl aes-256-cbc -K $encrypted_193118c4cca9_key -iv $encrypted_193118c4cca9_iv
     -in geo_deploy_key.enc -out geo_deploy_key -d
   - curl -sL https://raw.githubusercontent.com/shyiko/jabba/0.11.2/install.sh | bash && . ~/.jabba/jabba.sh
-  - mkdir /home/travis/bin
   - cd /home/travis/bin
   - curl -O https://raw.githubusercontent.com/technomancy/leiningen/stable/bin/lein
   - chmod +x /home/travis/bin/lein

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,12 +1,13 @@
-language: clojure
-jdk: oraclejdk8
-dist: trusty
+language: java
+jdk:
+  - openjdk11
 
 env:
   global:
   - secure: QYOLwEqrVn8dlT3qwznYXujR3x4ZE0WJcBeQoMVbofVMqwcC+xA4uOnfI1M0xQwzfYCD92mIUSoc0KGQGI7jCT2dcr2di2BEJZvIV4ra+CqgoHMJYd9S/hZCZuQWygX3MhBPl17jSKi2NQPAKu7tuP12Yd5GNBttiYOOyRFMdjY=
   - secure: Ny8wgc/tZqRR9/mv3vHupyKz1hvl7krMx+qCEILwsvgPZZg0fVTzZ+48HHzQ0CoNKY+u9PBHLuxPBkma5NM4NpdbsCySN6stqpIQJW7IwYvm6i2TkYHTD3BFv4MAkzxwON71Z1rUjCD3moh3TQGNVW+xNUv17UxUDB6KlK9BGS8=
   - JABBA_HOME: /home/travis/.jabba
+  - PATH: "/home/travis/bin:$PATH"
   matrix:
   - TRAVIS_JDK=amazon-corretto@1.8.222-10.1
   - TRAVIS_JDK=amazon-corretto@1.11.0-4.11.1
@@ -18,6 +19,10 @@ before_install:
   - openssl aes-256-cbc -K $encrypted_193118c4cca9_key -iv $encrypted_193118c4cca9_iv
     -in geo_deploy_key.enc -out geo_deploy_key -d
   - curl -sL https://raw.githubusercontent.com/shyiko/jabba/0.11.2/install.sh | bash && . ~/.jabba/jabba.sh
+  - mkdir /home/travis/bin
+  - cd /home/travis/bin
+  - curl -O https://raw.githubusercontent.com/technomancy/leiningen/stable/bin/lein
+  - chmod +x /home/travis/bin/lein
   - lein deps
 
 install:
@@ -34,7 +39,7 @@ jobs:
     - stage: deploy
       on:
         branch: master
-      jdk: oraclejdk8
+      jdk: openjdk11
       skip_cleanup: true
       env:
         - TRAVIS_JDK: amazon-corretto@1.11.0-4.11.1

--- a/.travis.yml
+++ b/.travis.yml
@@ -21,7 +21,7 @@ before_install:
   - cd /home/travis/bin
   - curl -O https://raw.githubusercontent.com/technomancy/leiningen/stable/bin/lein
   - chmod +x /home/travis/bin/lein
-  - cd /home/travis/Factual/geo
+  - cd $TRAVIS_BUILD_DIR
   - lein deps
 
 install:

--- a/.travis.yml
+++ b/.travis.yml
@@ -11,7 +11,6 @@ env:
   - TRAVIS_JDK=amazon-corretto@1.8.222-10.1
   - TRAVIS_JDK=amazon-corretto@1.11.0-4.11.1
   - TRAVIS_JDK=openjdk@1.12.0-2
-  - TRAVIS_JDK=adopt-openj9@1.8.222-10
   - TRAVIS_JDK=adopt-openj9@1.11.0-4
 
 before_install:

--- a/.travis.yml
+++ b/.travis.yml
@@ -11,7 +11,9 @@ env:
   - TRAVIS_JDK=amazon-corretto@1.8.222-10.1
   - TRAVIS_JDK=amazon-corretto@1.11.0-4.11.1
   - TRAVIS_JDK=openjdk@1.12.0-2
+  - TRAVIS_JDK=adopt-openj9@1.8.222-10
   - TRAVIS_JDK=adopt-openj9@1.11.0-4
+  - TRAVIS_JDK=adopt-openj9@1.12.0-2
 
 before_install:
   - openssl aes-256-cbc -K $encrypted_193118c4cca9_key -iv $encrypted_193118c4cca9_iv
@@ -46,4 +48,5 @@ jobs:
 cache:
   directories:
     - $HOME/.jabba/jdk
+    - $HOME/.m2
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,24 +1,43 @@
 language: clojure
-script: lein with-profile dev:+1.9:+1.8:+1.7 midje
 dist: trusty
-jdk:
-  - oraclejdk8
-  - openjdk8
-  - openjdk11
-  - openjdk12
-  - openjdk13
+
+env:
+  global:
+  - secure: QYOLwEqrVn8dlT3qwznYXujR3x4ZE0WJcBeQoMVbofVMqwcC+xA4uOnfI1M0xQwzfYCD92mIUSoc0KGQGI7jCT2dcr2di2BEJZvIV4ra+CqgoHMJYd9S/hZCZuQWygX3MhBPl17jSKi2NQPAKu7tuP12Yd5GNBttiYOOyRFMdjY=
+  - secure: Ny8wgc/tZqRR9/mv3vHupyKz1hvl7krMx+qCEILwsvgPZZg0fVTzZ+48HHzQ0CoNKY+u9PBHLuxPBkma5NM4NpdbsCySN6stqpIQJW7IwYvm6i2TkYHTD3BFv4MAkzxwON71Z1rUjCD3moh3TQGNVW+xNUv17UxUDB6KlK9BGS8=
+  - JABBA_HOME: /home/travis/.jabba
+  matrix:
+  - TRAVIS_JDK=amazon-corretto@1.8.222-10.1
+  - TRAVIS_JDK=amazon-corretto@1.11.0-4.11.1
+  - TRAVIS_JDK=openjdk@1.12.0-2
+  - TRAVIS_JDK=adopt-openj9@1.8.222-10
+  - TRAVIS_JDK=adopt-openj9@1.11.0-4
+
 before_install:
-- openssl aes-256-cbc -K $encrypted_193118c4cca9_key -iv $encrypted_193118c4cca9_iv
-  -in geo_deploy_key.enc -out geo_deploy_key -d
+  - openssl aes-256-cbc -K $encrypted_193118c4cca9_key -iv $encrypted_193118c4cca9_iv
+    -in geo_deploy_key.enc -out geo_deploy_key -d
+  - curl -sL https://raw.githubusercontent.com/shyiko/jabba/0.11.2/install.sh | bash && . ~/.jabba/jabba.sh
+
+install:
+  - $JABBA_HOME/bin/jabba install $TRAVIS_JDK
+  - unset _JAVA_OPTIONS
+  - export JAVA_HOME="$JABBA_HOME/jdk/$TRAVIS_JDK"
+  - jabba use $TRAVIS_JDK
+  - java -version
+
+script: lein with-profile dev:+1.9:+1.8:+1.7 midje
+
 jobs:
   include:
     - stage: deploy
       on:
         branch: master
       skip_cleanup: true
-      jdk: openjdk11
-      script: scripts/release.sh
-env:
-  global:
-  - secure: QYOLwEqrVn8dlT3qwznYXujR3x4ZE0WJcBeQoMVbofVMqwcC+xA4uOnfI1M0xQwzfYCD92mIUSoc0KGQGI7jCT2dcr2di2BEJZvIV4ra+CqgoHMJYd9S/hZCZuQWygX3MhBPl17jSKi2NQPAKu7tuP12Yd5GNBttiYOOyRFMdjY=
-  - secure: Ny8wgc/tZqRR9/mv3vHupyKz1hvl7krMx+qCEILwsvgPZZg0fVTzZ+48HHzQ0CoNKY+u9PBHLuxPBkma5NM4NpdbsCySN6stqpIQJW7IwYvm6i2TkYHTD3BFv4MAkzxwON71Z1rUjCD3moh3TQGNVW+xNUv17UxUDB6KlK9BGS8=
+      env:
+        - TRAVIS_JDK: amazon-corretto@1.11.0-4.11.1
+          script: scripts/release.sh
+
+cache:
+  directories:
+    - $HOME/.jabba/jdk
+

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,4 +1,5 @@
 language: clojure
+jdk: oraclejdk8
 dist: trusty
 
 env:
@@ -17,6 +18,7 @@ before_install:
   - openssl aes-256-cbc -K $encrypted_193118c4cca9_key -iv $encrypted_193118c4cca9_iv
     -in geo_deploy_key.enc -out geo_deploy_key -d
   - curl -sL https://raw.githubusercontent.com/shyiko/jabba/0.11.2/install.sh | bash && . ~/.jabba/jabba.sh
+  - lein deps
 
 install:
   - $JABBA_HOME/bin/jabba install $TRAVIS_JDK
@@ -32,6 +34,7 @@ jobs:
     - stage: deploy
       on:
         branch: master
+      jdk: oraclejdk8
       skip_cleanup: true
       env:
         - TRAVIS_JDK: amazon-corretto@1.11.0-4.11.1

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,7 +11,7 @@
 * Add `get-res-0-indexes` function for H3, which returns a collection of all indexes at resolution 0
 * Add `get-faces` function for H3, which returns the icosahedron faces intersected by a cell, represented by integers 0-19.
 * Add `line-segment`, `multi-point`, `multi-linestring`, and `multi-linestring-wkt` functions to `geo.jts`
-* Add testing support for OpenJDK 8, OpenJDK 11, OpenJDK 12, OpenJ9 8, OpenJ9 11, and Clojure 1.10
+* Add testing support for OpenJDK 8, OpenJDK 11, OpenJDK 12, OpenJ9 11, and Clojure 1.10
 * Fix reflection on geometry creation functions in the `jts` namespace
 * Bump `h3` to 3.5.0, enabling support for functions described above
 * Bump other core dependencies to keep up with upstream changes: `jts2geojson` to 0.14.2, and `jts` to 1.16.1

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,13 +4,14 @@
 
 * **Breaking change**: switch upstream `proj4j` to use `[org.locationtech.proj4j/proj4j "1.0.0"]`, changing namespace from `org.osgeo.proj4j` to `org.locationtech.proj4j`
 * **Breaking change**: rename `proj4-string?` to `proj4-str?`, to maintain naming consistency in the API
+* **Breaking change**: remove `jts-earth` from `geo.spatial`, and replace all uses of deprecated `spatial4j` functions using that `JtsShapeFactory` with functions using the `SpatialContext` `earth`
 * Allow `transform-geom` to use externally created `proj4j` `CoordinateTransform` objects
 * `geo.io` readers and writers are now thread-safe
 * Add `h3-line` function to H3 protocol, which returns the line of indexes between two cells
 * Add `get-res-0-indexes` function for H3, which returns a collection of all indexes at resolution 0
 * Add `get-faces` function for H3, which returns the icosahedron faces intersected by a cell, represented by integers 0-19.
 * Add `line-segment`, `multi-point`, `multi-linestring`, and `multi-linestring-wkt` functions to `geo.jts`
-* Add testing support for JDK11, JDK12, JDK13, and Clojure 1.10
+* Add testing support for OpenJDK 8, OpenJDK 11, OpenJDK 12, OpenJ9 8, OpenJ9 11, and Clojure 1.10
 * Fix reflection on geometry creation functions in the `jts` namespace
 * Bump `h3` to 3.5.0, enabling support for functions described above
 * Bump other core dependencies to keep up with upstream changes: `jts2geojson` to 0.14.2, and `jts` to 1.16.1

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,7 +11,7 @@
 * Add `get-res-0-indexes` function for H3, which returns a collection of all indexes at resolution 0
 * Add `get-faces` function for H3, which returns the icosahedron faces intersected by a cell, represented by integers 0-19.
 * Add `line-segment`, `multi-point`, `multi-linestring`, and `multi-linestring-wkt` functions to `geo.jts`
-* Add testing support for OpenJDK 8, OpenJDK 11, OpenJDK 12, OpenJ9 11, and Clojure 1.10
+* Add testing support for OpenJDK 8, OpenJDK 11, OpenJDK 12, OpenJ9 alongside HotSpot, and Clojure 1.10
 * Fix reflection on geometry creation functions in the `jts` namespace
 * Bump `h3` to 3.5.0, enabling support for functions described above
 * Bump other core dependencies to keep up with upstream changes: `jts2geojson` to 0.14.2, and `jts` to 1.16.1

--- a/src/geo/geohash.clj
+++ b/src/geo/geohash.clj
@@ -4,6 +4,7 @@
             [geo.jts :as jts])
   (:import (ch.hsr.geohash WGS84Point GeoHash)
            (org.locationtech.spatial4j.shape Shape)
+           (org.locationtech.spatial4j.shape.impl RectangleImpl)
            (org.locationtech.spatial4j.context.jts JtsSpatialContext)))
 
 (defn geohash
@@ -20,11 +21,11 @@
 
 (defn bbox ^Shape [^GeoHash geohash]
   (let [box (.getBoundingBox geohash)]
-    (.rect spatial/jts-earth
-           (.getMinLon box)
-           (.getMaxLon box)
-           (.getMinLat box)
-           (.getMaxLat box))))
+    (RectangleImpl. (.getMinLon box)
+                    (.getMaxLon box)
+                    (.getMinLat box)
+                    (.getMaxLat box)
+                    spatial/earth)))
 
 (defn bbox-geom ^org.locationtech.jts.geom.Polygon [^GeoHash geohash]
   (jts/set-srid (.getGeometryFrom JtsSpatialContext/GEO (bbox geohash))

--- a/test/geo/t_geohash.clj
+++ b/test/geo/t_geohash.clj
@@ -8,7 +8,8 @@
   (:import (ch.hsr.geohash GeoHash)
            (org.locationtech.jts.geom PrecisionModel
                                       Envelope
-                                      GeometryFactory)))
+                                      GeometryFactory)
+           (org.locationtech.spatial4j.shape.impl RectangleImpl)))
 
 (facts "geohash"
        (fact (geohash 50 20 64) => (partial instance? GeoHash))
@@ -212,7 +213,7 @@
 
 (facts "Getting bounding Shapes for geohashes"
        (let [gh (geohash "9q5")]
-         (bbox gh) => (.rect spatial/jts-earth -119.53125 -118.125 33.75 35.15625)
+         (bbox gh) => (RectangleImpl. -119.53125 -118.125 33.75 35.15625 spatial/earth)
          (bbox gh) => (spatial/to-shape gh)))
 
 (comment


### PR DESCRIPTION
Using [OpenJ9](https://www.eclipse.org/openj9/) was causing the midje tests to fail occasionally and unpredictably. Switching away from the [deprecated](https://locationtech.github.io/spatial4j/apidocs/org/locationtech/spatial4j/context/jts/JtsSpatialContext.html) functions in `JtsSpatialContext` seems to correct this issue. This also means that `jts-earth` in `geo.spatial` is no longer necessary, since all functions can be called using only `earth` instead.

In addition to these changes, this PR adds OpenJ9 to the test matrix, using [jabba](https://github.com/shyiko/jabba) to manage jdk versioning.