### PR TITLE
Update jts2geojson to 0.14.3 and update jdks for testing

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -8,12 +8,12 @@ env:
   - secure: Ny8wgc/tZqRR9/mv3vHupyKz1hvl7krMx+qCEILwsvgPZZg0fVTzZ+48HHzQ0CoNKY+u9PBHLuxPBkma5NM4NpdbsCySN6stqpIQJW7IwYvm6i2TkYHTD3BFv4MAkzxwON71Z1rUjCD3moh3TQGNVW+xNUv17UxUDB6KlK9BGS8=
   - JABBA_HOME: /home/travis/.jabba
   matrix:
-  - TRAVIS_JDK=amazon-corretto@1.8.222-10.1
-  - TRAVIS_JDK=amazon-corretto@1.11.0-4.11.1
-  - TRAVIS_JDK=openjdk@1.13.0
-  - TRAVIS_JDK=adopt-openj9@1.8.0-222
-  - TRAVIS_JDK=adopt-openj9@1.11.0-4
-  - TRAVIS_JDK=adopt-openj9@1.13.0-0
+  - TRAVIS_JDK=amazon-corretto@1.8.232-09.1
+  - TRAVIS_JDK=amazon-corretto@1.11.0-5.10.1
+  - TRAVIS_JDK=openjdk@1.13.0-1
+  - TRAVIS_JDK=adopt-openj9@1.8.0-232
+  - TRAVIS_JDK=adopt-openj9@1.11.0-5
+  - TRAVIS_JDK=adopt-openj9@1.13.0-1
 
 before_install:
   - openssl aes-256-cbc -K $encrypted_193118c4cca9_key -iv $encrypted_193118c4cca9_iv
@@ -41,7 +41,7 @@ jobs:
         branch: master
       skip_cleanup: true
       env:
-        - TRAVIS_JDK: amazon-corretto@1.11.0-4.11.1
+        - TRAVIS_JDK: amazon-corretto@1.11.0-5.10.1
       script: scripts/release.sh
 
 cache:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## Unreleased
+
+* Bump `jts2geojson` to 0.14.3
+
 ## 2.1.1 to 3.0.0
 
 * **Breaking change**: switch upstream `proj4j` to use `[org.locationtech.proj4j/proj4j "1.1.0"]`, changing namespace from `org.osgeo.proj4j` to `org.locationtech.proj4j`

--- a/deps.edn
+++ b/deps.edn
@@ -14,6 +14,6 @@
         org.locationtech.jts/jts-core #:mvn{:version "1.16.1"},
         org.locationtech.proj4j/proj4j #:mvn{:version "1.1.0"},
         org.locationtech.spatial4j/spatial4j #:mvn{:version "0.7"},
-        org.wololo/jts2geojson #:mvn{:version "0.14.2"}},
+        org.wololo/jts2geojson #:mvn{:version "0.14.3"}},
  :mvn/repos {"releases" {:url "https://clojars.org/repo"},
              "snapshots" {:url "https://clojars.org/repo"}}}

--- a/project.clj
+++ b/project.clj
@@ -14,7 +14,7 @@
    [org.locationtech.spatial4j/spatial4j "0.7"]
    [org.locationtech.jts/jts-core "1.16.1"]
    [org.locationtech.jts.io/jts-io-common "1.16.1"]
-   [org.wololo/jts2geojson "0.14.2"]]
+   [org.wololo/jts2geojson "0.14.3"]]
   :codox {:themes [:rdash]}
   :profiles {:dev {:global-vars {*warn-on-reflection* true}
                    :plugins [[lein-midje "3.2.1"]
@@ -24,6 +24,10 @@
                                   [codox-theme-rdash "0.1.2"]
                                   [criterium "0.4.5"]
                                   [cheshire "5.9.0"]
+                                  ;; Can remove jackson dependency once cheshire cuts release
+                                  [com.fasterxml.jackson.core/jackson-core "2.10.0"]
+                                  [com.fasterxml.jackson.dataformat/jackson-dataformat-cbor "2.10.0"]
+                                  [com.fasterxml.jackson.dataformat/jackson-dataformat-smile "2.10.0"]
                                   [midje "1.9.9"]]}
              :1.9 {:dependencies [[org.clojure/clojure "1.9.0"]]}
              :1.8 {:dependencies [[org.clojure/clojure "1.8.0"]]}


### PR DESCRIPTION
@worace If it's okay with you, I'll cut a 3.0.1 release based on these changes. No new functionality changes here, but the latest `jts2geojson` uses [`jackson` 2.10](https://medium.com/@cowtowncoder/jackson-2-10-features-cd880674d8a2), which sounds worth upgrading to.