### PR TITLE
Improve transform-geom, set-srid, and Transformable

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -11,9 +11,9 @@ env:
   - TRAVIS_JDK=zulu@1.8.242
   - TRAVIS_JDK=zulu@1.11.0-6
   - TRAVIS_JDK=openjdk@1.13.0-2
-  - TRAVIS_JDK=adopt-openj9@1.8.0-232
+  - TRAVIS_JDK=adopt-openj9@1.8.0-242
   - TRAVIS_JDK=adopt-openj9@1.11.0-6
-  - TRAVIS_JDK=adopt-openj9@1.13.0-1
+  - TRAVIS_JDK=adopt-openj9@1.13.0-2
 
 before_install:
   - openssl aes-256-cbc -K $encrypted_193118c4cca9_key -iv $encrypted_193118c4cca9_iv

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 ## Unreleased
 
-* **Deprecation**: Move `jts/transform-geom`, `jts/get-srid`, `jts/set-srid`, `jts/pm`, `jts/default-srid`, `jts/gf-wgs84` to `geo.crs`, leaving aliases in `geo.jts` during deprecation.
+* **Deprecation**: Move `jts/transform-geom`, `jts/get-srid`, `jts/set-srid`, `jts/pm`, `jts/default-srid`, and `jts/gf-wgs84` to `geo.crs`, leaving aliases in `geo.jts` during deprecation.
 * **Deprecation**: Deprecate `jts/gf` in favor of `crs/get-geometry-factory`, leaving alias in `geo.jts` during deprecation.
 * **Deprecation**: Deprecate `jts/get-factory` in favor of `crs/get-geometry-factory`, leaving alias in `geo.jts` during deprecation.
 * **Deprecation**: Deprecate `jts/polygons` in favor of `jts/geometries`, leaving alias in place during deprecation.
@@ -13,7 +13,7 @@
 * Modify `set-srid` to use `.createGeometry` instead of `.setSRID`, improving passthrough of projections within geometries and reducing need to manually set projections after operations
 * Add `get-geometry-factory` to `Transformable`, and extend `Transformable` to `Geometry` and `GeometryFactory`
 * Add `transform-helper` and `create-transform` to `Transformable`, and extend `Transformable` to `CoordinateTransform`
-* Allow `transform-geom` to accept `GeometryFactory` as a final argument, passing `transform-geom` to protocol-based `transform-helper` to improve dispatch
+* Allow `transform-geom` to accept `GeometryFactory` as a second argument, passing `transform-geom` to protocol-based `transform-helper` to improve dispatch
 * Allow `to-jts` to accept all of the argument arities of `transform-geom`
 * Add `get-parameters` and `get-parameter-string` functions to `geo.crs`
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@
 * Add `get-geometry-factory` to `Transformable`, and extend `Transformable` to `Geometry` and `GeometryFactory`
 * Use improved `set-srid` and `Transformable` to streamline functionality
 * Allow `transform-geom` to accept `GeometryFactory` as a final argument
+* Allow `to-jts` to accept all of the argument arities of `transform-geom`
 * Add `get-parameters` and `get-parameter-string` functions to `geo.crs`
 
 ## 3.0.0 to 3.0.1

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,10 +2,18 @@
 
 ## Unreleased
 
+* *Deprecation*: Move `jts/pm`, `jts/default-srid`, and `jts/gf-wgs84` to `geo.crs`, leaving aliases in `geo.jts` during deprecation
+* *Deprecation*: Deprecate `jts/gf` in favor of `crs/get-geometry-factory`, leaving alias in `geo.jts` during deprecation
+* *Deprecation*: Deprecate `jts/get-factory` in favor of `crs/get-geometry-factory`, leaving alias in `geo.jts` during deprecation
+* *Deprecation*: Deprecate `jts/get-srid` in favor of `crs/get-srid`, leaving alias in `geo.jts` during deprecation
+* *Deprecation*: Deprecate `jts/polygons` in favor of `jts/geometries`, leaving alias in place during deprecation.
 * Bump `geohash` to 1.4.0, which can use bounding boxes over the meridian
 * For development, bump `lein-midje` to 3.2.2 and `jackson` to 2.10.2
 * Bump `h3` to 3.6.3
 * Remove singularity error with `distance` by using spheroidal `spatial4j` Vincenty calculation when input point is at a pole, but otherwise using the `geohash` ellipsoidal Vincenty calculation.
+* Modify `set-srid` to use `.createGeometry` instead of `.setSRID`, improving passthrough of projections within geometries and reducing need to manually set projections after operations
+* Add `get-geometry-factory` to `Transformable`, and extend `Transformable` to `Geometry` and `GeometryFactory`
+* Use improved `set-srid` and `Transformable` to streamline functionality
 
 ## 3.0.0 to 3.0.1
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@
 * Modify `set-srid` to use `.createGeometry` instead of `.setSRID`, improving passthrough of projections within geometries and reducing need to manually set projections after operations
 * Add `get-geometry-factory` to `Transformable`, and extend `Transformable` to `Geometry` and `GeometryFactory`
 * Use improved `set-srid` and `Transformable` to streamline functionality
+* Allow `transform-geom` to accept `GeometryFactory` as a final argument
 
 ## 3.0.0 to 3.0.1
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,19 +2,21 @@
 
 ## Unreleased
 
-* **Deprecation**: Move `jts/pm`, `jts/default-srid`, and `jts/gf-wgs84` to `geo.crs`, leaving aliases in `geo.jts` during deprecation
-* **Deprecation**: Deprecate `jts/gf` in favor of `crs/get-geometry-factory`, leaving alias in `geo.jts` during deprecation
-* **Deprecation**: Deprecate `jts/get-factory` in favor of `crs/get-geometry-factory`, leaving alias in `geo.jts` during deprecation
-* **Deprecation**: Deprecate `jts/get-srid` in favor of `crs/get-srid`, leaving alias in `geo.jts` during deprecation
+* **Deprecation**: Move `jts/pm`, `jts/default-srid`, and `jts/gf-wgs84` to `geo.crs`, leaving aliases in `geo.jts` during deprecation.
+* **Deprecation**: Deprecate `jts/gf` in favor of `crs/get-geometry-factory`, leaving alias in `geo.jts` during deprecation.
+* **Deprecation**: Deprecate `jts/get-factory` in favor of `crs/get-geometry-factory`, leaving alias in `geo.jts` during deprecation.
+* **Deprecation**: Deprecate `jts/get-srid` in favor of `crs/get-srid`, leaving alias in `geo.jts` during deprecation.
+* **Deprecation**: Deprecate `jts/set-srid` in favor of `crs/set-srid`, leaving alias in `geo.jts` during deprecation.
+* **Deprecation**: Deprecate `jts/transform-geom` in favor of `crs/transform-geom`, leaving alias in `geo.jts` during deprecation.
 * **Deprecation**: Deprecate `jts/polygons` in favor of `jts/geometries`, leaving alias in place during deprecation.
 * Bump `geohash` to 1.4.0, which can use bounding boxes over the meridian
-* For development, bump `lein-midje` to 3.2.2 and `jackson` to 2.10.2
+* For development, bump `lein-midje` to 3.2.2 and `cheshire` to 5.10.0, removing extra `jackson` dependencies
 * Bump `h3` to 3.6.3
 * Remove singularity error with `distance` by using spheroidal `spatial4j` Vincenty calculation when input point is at a pole, but otherwise using the `geohash` ellipsoidal Vincenty calculation.
 * Modify `set-srid` to use `.createGeometry` instead of `.setSRID`, improving passthrough of projections within geometries and reducing need to manually set projections after operations
 * Add `get-geometry-factory` to `Transformable`, and extend `Transformable` to `Geometry` and `GeometryFactory`
-* Use improved `set-srid` and `Transformable` to streamline functionality
-* Allow `transform-geom` to accept `GeometryFactory` as a final argument
+* Add `transform-helper` and `create-transform` to `Transformable`, and extend `Transformable` to `CoordinateTransform`
+* Allow `transform-geom` to accept `GeometryFactory` as a final argument, passing `transform-geom` to protocol-based `transform-helper` to improve dispatch
 * Allow `to-jts` to accept all of the argument arities of `transform-geom`
 * Add `get-parameters` and `get-parameter-string` functions to `geo.crs`
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,12 +2,9 @@
 
 ## Unreleased
 
-* **Deprecation**: Move `jts/pm`, `jts/default-srid`, and `jts/gf-wgs84` to `geo.crs`, leaving aliases in `geo.jts` during deprecation.
+* **Deprecation**: Move `jts/transform-geom`, `jts/get-srid`, `jts/set-srid`, `jts/pm`, `jts/default-srid`, `jts/gf-wgs84` to `geo.crs`, leaving aliases in `geo.jts` during deprecation.
 * **Deprecation**: Deprecate `jts/gf` in favor of `crs/get-geometry-factory`, leaving alias in `geo.jts` during deprecation.
 * **Deprecation**: Deprecate `jts/get-factory` in favor of `crs/get-geometry-factory`, leaving alias in `geo.jts` during deprecation.
-* **Deprecation**: Deprecate `jts/get-srid` in favor of `crs/get-srid`, leaving alias in `geo.jts` during deprecation.
-* **Deprecation**: Deprecate `jts/set-srid` in favor of `crs/set-srid`, leaving alias in `geo.jts` during deprecation.
-* **Deprecation**: Deprecate `jts/transform-geom` in favor of `crs/transform-geom`, leaving alias in `geo.jts` during deprecation.
 * **Deprecation**: Deprecate `jts/polygons` in favor of `jts/geometries`, leaving alias in place during deprecation.
 * Bump `geohash` to 1.4.0, which can use bounding boxes over the meridian
 * For development, bump `lein-midje` to 3.2.2 and `cheshire` to 5.10.0, removing extra `jackson` dependencies

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,11 +2,11 @@
 
 ## Unreleased
 
-* *Deprecation*: Move `jts/pm`, `jts/default-srid`, and `jts/gf-wgs84` to `geo.crs`, leaving aliases in `geo.jts` during deprecation
-* *Deprecation*: Deprecate `jts/gf` in favor of `crs/get-geometry-factory`, leaving alias in `geo.jts` during deprecation
-* *Deprecation*: Deprecate `jts/get-factory` in favor of `crs/get-geometry-factory`, leaving alias in `geo.jts` during deprecation
-* *Deprecation*: Deprecate `jts/get-srid` in favor of `crs/get-srid`, leaving alias in `geo.jts` during deprecation
-* *Deprecation*: Deprecate `jts/polygons` in favor of `jts/geometries`, leaving alias in place during deprecation.
+* **Deprecation**: Move `jts/pm`, `jts/default-srid`, and `jts/gf-wgs84` to `geo.crs`, leaving aliases in `geo.jts` during deprecation
+* **Deprecation**: Deprecate `jts/gf` in favor of `crs/get-geometry-factory`, leaving alias in `geo.jts` during deprecation
+* **Deprecation**: Deprecate `jts/get-factory` in favor of `crs/get-geometry-factory`, leaving alias in `geo.jts` during deprecation
+* **Deprecation**: Deprecate `jts/get-srid` in favor of `crs/get-srid`, leaving alias in `geo.jts` during deprecation
+* **Deprecation**: Deprecate `jts/polygons` in favor of `jts/geometries`, leaving alias in place during deprecation.
 * Bump `geohash` to 1.4.0, which can use bounding boxes over the meridian
 * For development, bump `lein-midje` to 3.2.2 and `jackson` to 2.10.2
 * Bump `h3` to 3.6.3

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@
 * Add `get-geometry-factory` to `Transformable`, and extend `Transformable` to `Geometry` and `GeometryFactory`
 * Use improved `set-srid` and `Transformable` to streamline functionality
 * Allow `transform-geom` to accept `GeometryFactory` as a final argument
+* Add `get-parameters` and `get-parameter-string` functions to `geo.crs`
 
 ## 3.0.0 to 3.0.1
 

--- a/project.clj
+++ b/project.clj
@@ -23,11 +23,7 @@
                    :dependencies [[org.clojure/clojure "1.10.1"]
                                   [codox-theme-rdash "0.1.2"]
                                   [criterium "0.4.5"]
-                                  [cheshire "5.9.0"]
-                                  ;; Can remove jackson dependency once cheshire cuts release
-                                  [com.fasterxml.jackson.core/jackson-core "2.10.2"]
-                                  [com.fasterxml.jackson.dataformat/jackson-dataformat-cbor "2.10.2"]
-                                  [com.fasterxml.jackson.dataformat/jackson-dataformat-smile "2.10.2"]
+                                  [cheshire "5.10.0"]
                                   [midje "1.9.9"]]}
              :1.9 {:dependencies [[org.clojure/clojure "1.9.0"]]}
              :1.8 {:dependencies [[org.clojure/clojure "1.8.0"]]}

--- a/src/geo/crs.clj
+++ b/src/geo/crs.clj
@@ -143,7 +143,9 @@
    - a long (which will be interpreted as that EPSG)
    - an integer (which will be interpreted as that EPSG)
    - a string identifier for types EPSG:XXXX, ESRI:XXXX, WORLD:XXXX, NAD83:XXXX, or NAD27:XXXX
-   - a proj4 string, or
-   - a proj4j CoordinateReferenceSystem"
+   - a proj4 string
+   - a proj4j CoordinateReferenceSystem
+   - a JTS Geometry (using its SRID), or
+   - a JTS GeometryFactory"
   (.createTransform ctf-factory (create-crs c1) (create-crs c2)))
 

--- a/src/geo/crs.clj
+++ b/src/geo/crs.clj
@@ -258,14 +258,13 @@
     ([this g]
      (transform-helper this g (create-transform g this)))
     ([this g t]
-     (cond (instance? CoordinateTransform t)
-           ;; Base case: geometryfactory, geometry, coordinatetransform
-           (if (.equals (get-source-crs t)
-                        (get-target-crs t))
-             (set-srid g this)
-             (tf g t this))
-           :else
-           (transform-helper t g this)))
+     (if (instance? CoordinateTransform t)
+       ;; Base case: GeometryFactory, Geometry, CoordinateTransform
+       (if (.equals (get-source-crs t)
+                    (get-target-crs t))
+         (set-srid g this)
+         (tf g t this))
+       (transform-helper t g this)))
     ([this g c1 c2]
      (transform-helper this g (create-transform c1 c2)))))
 
@@ -273,6 +272,18 @@
 (def ^GeometryFactory gf-wgs84 (get-geometry-factory default-srid))
 
 (defn transform-geom
+  "Transforms a Geometry to a different Coordinate Reference System.
+   Takes a Geometry as a first argument, and either one, two, or three
+   Transformables as additional arguments. When the final argument is
+   a GeometryFactory, use that factory to construct the new Geometry.
+   When only a target CRS is provided, use the Geometry's internal
+   SRID as the source CRS.
+
+   The most efficient way to call this is with its base case of
+   (transform-geom Geometry GeometryFactory CoordinateTransform).
+
+   All other argument calls to this function ultimately reduce
+   down to that base case."
   ([g t]
    (transform-helper t g))
   ([g c1 c2]

--- a/src/geo/crs.clj
+++ b/src/geo/crs.clj
@@ -184,7 +184,7 @@
     (create-transform (create-crs this) (create-crs tgt)))
   (transform-helper
     ([this g]
-     (transform-helper (create-transform g this) g (get-geometry-factory this)))
+     (transform-helper (get-geometry-factory this) g (create-transform g this)))
     ([this g c]
      (if (geom-srid? g)
        (transform-helper (get-geometry-factory c) g (create-transform g c))
@@ -218,12 +218,12 @@
   (transform-helper
     ([this g]
      (transform-helper
-      (create-transform (create-crs g) this) g (get-geometry-factory this)))
+      (get-geometry-factory this) g (create-transform (create-crs g) this)))
     ([this g c2]
      (transform-helper
-      (create-transform this (create-crs c2)) g (get-geometry-factory c2)))
+      (get-geometry-factory c2) g (create-transform this (create-crs c2))))
     ([this g c2 f]
-     (transform-helper (create-transform this c2) g f)))
+     (transform-helper (get-geometry-factory f) g (create-transform this c2))))
 
   Geometry
   (create-crs [this] (create-crs (get-srid this)))
@@ -235,9 +235,10 @@
     ([this t]
      (do (assert (geom-srid? this)
                  "Geometry must have a valid SRID to generate a transform.")
-         (transform-helper this t (get-geometry-factory t))))
+         (transform-helper (get-geometry-factory t) this t)))
     ([this c1 c2 gf]
-     (transform-helper gf this (create-transform c1 c2))))
+     (transform-helper
+      (get-geometry-factory gf) this (create-transform c1 c2))))
 
   CoordinateTransform
   (create-transform [this] this)
@@ -274,7 +275,7 @@
 (defn transform-geom
   "Transforms a Geometry to a different Coordinate Reference System.
    Takes a Geometry as a first argument, and either one, two, or three
-   Transformables as additional arguments. When the final argument is
+   Transformables as additional arguments. When the second argument is
    a GeometryFactory, use that factory to construct the new Geometry.
    When only a target CRS is provided, use the Geometry's internal
    SRID as the source CRS.

--- a/src/geo/crs.clj
+++ b/src/geo/crs.clj
@@ -1,10 +1,15 @@
 (ns geo.crs
-  "Helper functions for identifying and manipulating Coordinate Reference Systems."
+  "Helper functions for identifying and manipulating
+  Coordinate Reference Systems."
   (:import (org.locationtech.proj4j CoordinateReferenceSystem
                                     CoordinateTransform
                                     CoordinateTransformFactory
-                                    CRSFactory)
-           (org.locationtech.jts.geom Geometry
+                                    CRSFactory
+                                    ProjCoordinate)
+           (org.locationtech.jts.geom Coordinate
+                                      CoordinateSequence
+                                      CoordinateSequenceFilter
+                                      Geometry
                                       GeometryFactory
                                       PrecisionModel)))
 
@@ -51,7 +56,9 @@
 
 (defn- create-crs-number
   [c]
-  (.createFromName crs-factory (srid->epsg-str c)))
+  (let [valid? (not= c 0)]
+    (assert valid? "Cannot create CRS with EPSG 0")
+    (.createFromName crs-factory (srid->epsg-str c))))
 
 (defn- create-crs-name
   [c]
@@ -76,12 +83,12 @@
   [^CoordinateReferenceSystem c]
   (.getParameterString c))
 
-(defn get-source-crs
+(defn ^CoordinateReferenceSystem get-source-crs
   "Get the source coordinate reference system of a transform."
   [^CoordinateTransform t]
   (.getSourceCRS t))
 
-(defn get-target-crs
+(defn ^CoordinateReferenceSystem get-target-crs
   "Get the source coordinate reference system of a transform."
   [^CoordinateTransform t]
   (.getTargetCRS t))
@@ -94,18 +101,96 @@
   (^GeometryFactory get-geometry-factory [this]
    "Creates a JTS GeometryFactory from a given CRS identifier.")
   (^Integer get-srid [this]
-   "Attempt to get the SRID for a CRS identifier. If unable, return 0."))
+   "Attempt to get the SRID for a CRS identifier. If unable, return 0.")
+  (^CoordinateTransform create-transform [this] [this tgt])
+  (^Geometry ^:private transform-helper [this g] [this g c] [this g c gf]
+   "An internal helper to coordinate logic of jts/transform-geom."))
+
+(defn set-srid
+  "Sets a geometry's SRID to a new value, and returns that geometry."
+  [^Geometry geom srid]
+  (if (= (get-srid geom) (get-srid srid))
+      geom
+      (.createGeometry (get-geometry-factory srid) geom)))
+
+(defn- ^Coordinate transform-coord
+  "Transforms a coordinate using a proj4j transform.
+  Can either be specified with a transform argument
+  or two projection arguments."
+  ([^Coordinate coord ^CoordinateTransform transform]
+   (-> (.transform transform
+                   (ProjCoordinate. (.x coord) (.y coord) (.z coord))
+                   (ProjCoordinate.))
+       (#(Coordinate. (.x ^ProjCoordinate %)
+                      (.y ^ProjCoordinate %)
+                      (.z ^ProjCoordinate %)))))
+  ([coord c1 c2]
+   (if (= c1 c2) coord
+       (transform-coord coord (create-transform c1 c2)))))
+
+(defn- transform-coord-seq-item
+  "Transforms one item in a CoordinateSequence using a proj4j transform."
+  [^CoordinateSequence cseq ^Integer i ^CoordinateTransform transform]
+  (let [coordinate (.getCoordinate cseq i)
+        transformed (transform-coord coordinate transform)]
+    (.setOrdinate cseq i 0 (.x transformed))
+    (.setOrdinate cseq i 1 (.y transformed))))
+
+(defn- ^CoordinateSequenceFilter transform-coord-seq-filter
+  "Implement JTS's CoordinateSequenceFilter, to be applied to a
+  Geometry using tf and transform-geom."
+  [transform]
+  (reify CoordinateSequenceFilter
+    (filter [_ seq i]
+      (transform-coord-seq-item seq i transform))
+    (isDone [_]
+      false)
+    (isGeometryChanged [_]
+      true)))
+
+(defn- geom-srid?
+  "Check if a Geometry has a valid SRID."
+  [^Geometry g]
+  (let [geom-srid (get-srid g)]
+    (and (not= 0 geom-srid)
+         (not (nil? geom-srid)))))
+
+(defn- tf
+  "Transform a Geometry by applying CoordinateTransform to the Geometry.
+  When the target CRS has an SRID, set the geometry's SRID to that."
+  [^Geometry g ^CoordinateTransform transform ^GeometryFactory gf]
+  (let [g (.copy g)]
+    (.apply g (transform-coord-seq-filter transform))
+    (set-srid g gf)))
+
 
 (extend-protocol Transformable
   Long
   (create-crs [this] (create-crs-number this))
   (get-geometry-factory [this] (get-geometry-factory (get-srid this)))
   (get-srid [this] (int this))
+  (create-transform [this tgt]
+    (create-transform (create-crs this) (create-crs tgt)))
+  (transform-helper
+    ([this g] (transform-helper (get-srid this) g))
+    ([this g c] (transform-helper (get-srid this) g c))
+    ([this g c1 f] (transform-helper (get-srid this) g c1 f)))
 
   Integer
   (create-crs [this] (create-crs-number this))
   (get-geometry-factory [this] (GeometryFactory. pm this))
   (get-srid [this] this)
+  (create-transform [this tgt]
+    (create-transform (create-crs this) (create-crs tgt)))
+  (transform-helper
+    ([this g]
+     (transform-helper (create-transform g this) g (get-geometry-factory this)))
+    ([this g c]
+     (if (geom-srid? g)
+       (transform-helper (get-geometry-factory c) g (create-transform g c))
+       (transform-helper (get-geometry-factory c) g (create-transform this c))))
+    ([this g c2 f]
+     (transform-helper (get-geometry-factory f) g (create-transform this c2))))
 
   String
   (create-crs [this] (cond (crs-name? this)
@@ -117,35 +202,80 @@
                      (if epsg?
                        (read-string (last epsg?))
                        0)))
+  (create-transform [this tgt]
+    (create-transform (create-crs this) (create-crs tgt)))
+  (transform-helper
+    ([this g] (transform-helper (create-crs this) g))
+    ([this g c] (transform-helper (create-crs this) g c))
+    ([this g c1 f] (transform-helper (create-crs this) g c1 f)))
 
   CoordinateReferenceSystem
   (create-crs [this] this)
   (get-geometry-factory [this] (get-geometry-factory (get-srid this)))
   (get-srid [this] (get-srid (get-name this)))
+  (create-transform [this tgt]
+    (.createTransform ctf-factory this (create-crs tgt)))
+  (transform-helper
+    ([this g]
+     (transform-helper
+      (create-transform (create-crs g) this) g (get-geometry-factory this)))
+    ([this g c2]
+     (transform-helper
+      (create-transform this (create-crs c2)) g (get-geometry-factory c2)))
+    ([this g c2 f]
+     (transform-helper (create-transform this c2) g f)))
 
   Geometry
   (create-crs [this] (create-crs (get-srid this)))
   (get-geometry-factory [this] (.getFactory this))
   (get-srid [this] (.getSRID this))
+  (create-transform [this tgt]
+    (create-transform (create-crs this) (create-crs tgt)))
+  (transform-helper
+    ([this t]
+     (do (assert (geom-srid? this)
+                 "Geometry must have a valid SRID to generate a transform.")
+         (transform-helper this t (get-geometry-factory t))))
+    ([this c1 c2 gf]
+     (transform-helper gf this (create-transform c1 c2))))
+
+  CoordinateTransform
+  (create-transform [this] this)
+  (get-geometry-factory [this] (get-geometry-factory (get-target-crs this)))
+  (transform-helper
+    ([this g]
+     (transform-helper (get-geometry-factory this) g this))
+    ([this g factory]
+     (transform-helper (get-geometry-factory factory) g this)))
 
   GeometryFactory
   (create-crs [this] (create-crs (get-srid this)))
   (get-geometry-factory [this] this)
-  (get-srid [this] (.getSRID this)))
+  (get-srid [this] (.getSRID this))
+  (create-transform [this tgt]
+    (create-transform (create-crs this) (create-crs tgt)))
+  (transform-helper
+    ([this g]
+     (transform-helper this g (create-transform g this)))
+    ([this g t]
+     (cond (instance? CoordinateTransform t)
+           ;; Base case: geometryfactory, geometry, coordinatetransform
+           (if (.equals (get-source-crs t)
+                        (get-target-crs t))
+             (set-srid g this)
+             (tf g t this))
+           :else
+           (transform-helper t g this)))
+    ([this g c1 c2]
+     (transform-helper this g (create-transform c1 c2)))))
 
 (def default-srid (int 4326))
 (def ^GeometryFactory gf-wgs84 (get-geometry-factory default-srid))
 
-(defn create-transform
-  [c1 c2]
-  "Creates a proj4j transform between two projection systems.
-  c1 or c2 can be:
-   - a long (which will be interpreted as that EPSG)
-   - an integer (which will be interpreted as that EPSG)
-   - a string identifier for types EPSG:XXXX, ESRI:XXXX, WORLD:XXXX, NAD83:XXXX, or NAD27:XXXX
-   - a proj4 string
-   - a proj4j CoordinateReferenceSystem
-   - a JTS Geometry (using its SRID), or
-   - a JTS GeometryFactory"
-  (.createTransform ctf-factory (create-crs c1) (create-crs c2)))
-
+(defn transform-geom
+  ([g t]
+   (transform-helper t g))
+  ([g c1 c2]
+   (transform-helper c1 g c2))
+  ([g c1 c2 geometry-factory]
+   (transform-helper c1 g c2 geometry-factory)))

--- a/src/geo/crs.clj
+++ b/src/geo/crs.clj
@@ -66,6 +66,16 @@
   [^CoordinateReferenceSystem c]
   (.getName c))
 
+(defn get-parameters
+  "Get the proj parameters from an existing coordinate reference system."
+  [^CoordinateReferenceSystem c]
+  (.getParameters c))
+
+(defn get-parameter-string
+  "Get the proj string from an existing coordinate reference system."
+  [^CoordinateReferenceSystem c]
+  (.getParameterString c))
+
 (defn get-source-crs
   "Get the source coordinate reference system of a transform."
   [^CoordinateTransform t]

--- a/src/geo/crs.clj
+++ b/src/geo/crs.clj
@@ -92,7 +92,7 @@
     If given a valid CRS name or proj4 string, use that as the CRS identifier.
     If given a proj4j CoordinateReferenceSystem, return that.")
   (^GeometryFactory get-geometry-factory [this]
-   "Creates a CoordinateFactory or a GeometryFactory.")
+   "Creates a JTS GeometryFactory from a given CRS identifier.")
   (^Integer get-srid [this]
    "Attempt to get the SRID for a CRS identifier. If unable, return 0."))
 

--- a/src/geo/geohash.clj
+++ b/src/geo/geohash.clj
@@ -1,6 +1,7 @@
 (ns geo.geohash
   "Working with geohashes."
-  (:require [geo.spatial :as spatial]
+  (:require [geo.crs :as crs]
+            [geo.spatial :as spatial]
             [geo.jts :as jts])
   (:import (ch.hsr.geohash WGS84Point GeoHash)
            (org.locationtech.spatial4j.shape Shape)
@@ -29,7 +30,7 @@
 
 (defn bbox-geom ^org.locationtech.jts.geom.Polygon [^GeoHash geohash]
   (jts/set-srid (.getGeometryFrom JtsSpatialContext/GEO (bbox geohash))
-                jts/default-srid))
+                crs/default-srid))
 
 (extend-protocol spatial/Shapelike
   GeoHash

--- a/src/geo/geohash.clj
+++ b/src/geo/geohash.clj
@@ -35,19 +35,23 @@
 (extend-protocol spatial/Shapelike
   GeoHash
   (to-shape [^GeoHash geohash] (bbox geohash))
-  (to-jts ([^GeoHash geohash] (bbox-geom geohash))
-          ([^GeoHash geohash srid] (jts/set-srid (spatial/to-jts geohash) srid))
-          ([this c1 c2] (spatial/to-jts (spatial/to-jts this) c1 c2))
-          ([this c1 c2 geometry-factory] (spatial/to-jts (spatial/to-jts this)
-                                                         c1 c2 geometry-factory)))
+  (to-jts
+    ([^GeoHash geohash] (bbox-geom geohash))
+    ([^GeoHash geohash srid]
+     (spatial/to-jts (bbox-geom geohash) srid))
+    ([^GeoHash geohash c1 c2]
+     (spatial/to-jts (bbox-geom geohash) c1 c2))
+    ([^GeoHash geohash c1 c2 geometry-factory]
+     (spatial/to-jts (bbox-geom geohash) c1 c2 geometry-factory)))
 
   WGS84Point
   (to-shape [this] (spatial/spatial4j-point this))
-  (to-jts ([this] (spatial/jts-point this))
-          ([this srid] (spatial/to-jts (spatial/to-jts this) srid))
-          ([this c1 c2] (spatial/to-jts (spatial/to-jts this) c1 c2))
-          ([this c1 c2 geometry-factory] (spatial/to-jts (spatial/to-jts this)
-                                                         c1 c2 geometry-factory))))
+  (to-jts
+    ([this] (spatial/jts-point this))
+    ([this srid] (spatial/to-jts (spatial/jts-point this) srid))
+    ([this c1 c2] (spatial/to-jts (spatial/jts-point this) c1 c2))
+    ([this c1 c2 geometry-factory]
+     (spatial/to-jts (spatial/jts-point this) c1 c2 geometry-factory))))
 
 (defn northern-neighbor [^GeoHash h] (.getNorthernNeighbour h))
 (defn eastern-neighbor [^GeoHash h] (.getEasternNeighbour h))

--- a/src/geo/geohash.clj
+++ b/src/geo/geohash.clj
@@ -30,7 +30,7 @@
 
 (defn bbox-geom ^org.locationtech.jts.geom.Polygon [^GeoHash geohash]
   (jts/set-srid (.getGeometryFrom JtsSpatialContext/GEO (bbox geohash))
-                crs/default-srid))
+                crs/gf-wgs84))
 
 (extend-protocol spatial/Shapelike
   GeoHash

--- a/src/geo/geohash.clj
+++ b/src/geo/geohash.clj
@@ -36,12 +36,18 @@
   GeoHash
   (to-shape [^GeoHash geohash] (bbox geohash))
   (to-jts ([^GeoHash geohash] (bbox-geom geohash))
-          ([^GeoHash geohash srid] (jts/set-srid (spatial/to-jts geohash) srid)))
+          ([^GeoHash geohash srid] (jts/set-srid (spatial/to-jts geohash) srid))
+          ([this c1 c2] (spatial/to-jts (spatial/to-jts this) c1 c2))
+          ([this c1 c2 geometry-factory] (spatial/to-jts (spatial/to-jts this)
+                                                         c1 c2 geometry-factory)))
 
   WGS84Point
   (to-shape [this] (spatial/spatial4j-point this))
   (to-jts ([this] (spatial/jts-point this))
-          ([this srid] (spatial/to-jts (spatial/to-jts this) srid))))
+          ([this srid] (spatial/to-jts (spatial/to-jts this) srid))
+          ([this c1 c2] (spatial/to-jts (spatial/to-jts this) c1 c2))
+          ([this c1 c2 geometry-factory] (spatial/to-jts (spatial/to-jts this)
+                                                         c1 c2 geometry-factory))))
 
 (defn northern-neighbor [^GeoHash h] (.getNorthernNeighbour h))
 (defn eastern-neighbor [^GeoHash h] (.getEasternNeighbour h))

--- a/src/geo/h3.clj
+++ b/src/geo/h3.clj
@@ -1,6 +1,7 @@
 (ns geo.h3
   "Working with H3."
-  (:require [geo.spatial :as spatial]
+  (:require [geo.crs :as crs]
+            [geo.spatial :as spatial]
             [geo.jts :as jts]
             [clojure.string :as string]
             [clojure.walk :as walk]
@@ -426,7 +427,7 @@
   "Common logic used to polyfill a shapelike made of a single polygon.
   Used for both the string and long methods."
   [s]
-  (let [s (to-polygon s jts/default-srid)
+  (let [s (to-polygon s crs/default-srid)
         num-interior-rings (.getNumInteriorRing ^Polygon s)
         ext-ring (.getExteriorRing ^Polygon s)
         int-rings (map #(.getInteriorRingN ^Polygon s %) (range num-interior-rings))]
@@ -502,7 +503,7 @@
               (recur good-geoms (rest remaining-geoms))
               (instance? MultiPolygon current-poly)
               ; If a subdivided quadrant became a multipolygon, split that into its polygons and recur
-              (recur good-geoms (concat (jts/polygons current-poly) (rest remaining-geoms)))
+              (recur good-geoms (concat (jts/geometries current-poly) (rest remaining-geoms)))
               (< max-hexagons safe-polyfill-hexagon-maximum)
               ; If less than the safe maximum, the geometry is good to be polyfilled
               (recur (conj good-geoms current-poly) (rest remaining-geoms))
@@ -529,7 +530,7 @@
   [mp ^Integer res]
   (let [pf-polys (fn [p] (mapcat #(polyfill-address-check [%] res) p))]
     (into [] (-> mp
-                 jts/polygons
+                 jts/geometries
                  pf-polys
                  flatten))))
 
@@ -539,7 +540,7 @@
   [mp ^Integer res]
   (let [pf-polys (fn [p] (mapcat #(polyfill-check [%] res) p))]
     (into [] (-> mp
-                 jts/polygons
+                 jts/geometries
                  pf-polys
                  flatten))))
 

--- a/src/geo/h3.clj
+++ b/src/geo/h3.clj
@@ -427,7 +427,7 @@
   "Common logic used to polyfill a shapelike made of a single polygon.
   Used for both the string and long methods."
   [s]
-  (let [s (to-polygon s crs/default-srid)
+  (let [s (to-polygon s crs/gf-wgs84)
         num-interior-rings (.getNumInteriorRing ^Polygon s)
         ext-ring (.getExteriorRing ^Polygon s)
         int-rings (map #(.getInteriorRingN ^Polygon s %) (range num-interior-rings))]

--- a/src/geo/io.clj
+++ b/src/geo/io.clj
@@ -112,7 +112,7 @@
        :geometry #object[org.locationtech.jts.geom.Point(...)]}]
   "
   ([^String geojson]
-   (read-geojson geojson crs/default-srid))
+   (read-geojson geojson crs/gf-wgs84))
   ([^String geojson srid]
    (->> geojson
         parse-geojson
@@ -122,18 +122,18 @@
 (defn read-geojson-geometry
   "Parse a GeoJSON string representing a single Geometry into a JTS Geometry."
   ([^String geojson]
-   (read-geojson-geometry geojson crs/default-srid))
+   (read-geojson-geometry geojson crs/gf-wgs84))
   ([^String geojson srid]
    (-> geojson
        parse-geojson
        read-geometry
        (jts/set-srid srid))))
 
-(defn to-geojson [shapelike] (.toString (.write (GeoJSONWriter.) (to-jts shapelike crs/default-srid))))
+(defn to-geojson [shapelike] (.toString (.write (GeoJSONWriter.) (to-jts shapelike crs/gf-wgs84))))
 
 (defn- ^Feature gj-feature
   [{shapelike :geometry properties :properties}]
-  (let [gj-geom (.write (GeoJSONWriter.) (to-jts shapelike crs/default-srid))]
+  (let [gj-geom (.write (GeoJSONWriter.) (to-jts shapelike crs/gf-wgs84))]
     (Feature. gj-geom (stringify-keys properties))))
 
 (defn to-geojson-feature

--- a/src/geo/io.clj
+++ b/src/geo/io.clj
@@ -1,7 +1,8 @@
 (ns geo.io
   "Helper functions for converting JTS geometries to and from various
    geospatial IO formats (geojson, wkt, wkb)."
-  (:require [geo.jts :refer [gf-wgs84] :as jts]
+  (:require [geo.crs :as crs]
+            [geo.jts :as jts]
             [geo.spatial :refer [Shapelike to-jts]]
             [clojure.data]
             [clojure.walk :refer [keywordize-keys stringify-keys]])
@@ -18,17 +19,19 @@
 (defn read-wkt
   "Read a WKT string and convert to a Geometry.
    Can optionally pass in SRID. Defaults to WGS84"
-  ([^String wkt] (.read (WKTReader. gf-wgs84) wkt))
-  ([^String wkt srid] (.read (WKTReader. (jts/gf srid)) wkt)))
+  ([^String wkt] (.read (WKTReader. crs/gf-wgs84) wkt))
+  ([^String wkt srid] (.read (WKTReader.
+                              (crs/get-geometry-factory srid)) wkt)))
 
 (defn to-wkt [shapelike] (.write (WKTWriter.) (to-jts shapelike)))
 
 (defn read-wkb
   "Read a WKB byte array and convert to a Geometry.
    Can optionally pass in SRID. Defaults to WGS84"
-  ([^bytes bytes] (.read (WKBReader. gf-wgs84) bytes))
+  ([^bytes bytes] (.read (WKBReader. crs/gf-wgs84) bytes))
   ([^bytes bytes srid]
-   (.read (WKBReader. (jts/gf srid)) bytes)))
+   (.read (WKBReader.
+           (crs/get-geometry-factory srid)) bytes)))
 
 (defn read-wkb-hex
   "Read a WKB hex string and convert to a Geometry"
@@ -109,7 +112,7 @@
        :geometry #object[org.locationtech.jts.geom.Point(...)]}]
   "
   ([^String geojson]
-   (read-geojson geojson jts/default-srid))
+   (read-geojson geojson crs/default-srid))
   ([^String geojson srid]
    (->> geojson
         parse-geojson
@@ -119,18 +122,18 @@
 (defn read-geojson-geometry
   "Parse a GeoJSON string representing a single Geometry into a JTS Geometry."
   ([^String geojson]
-   (read-geojson-geometry geojson jts/default-srid))
+   (read-geojson-geometry geojson crs/default-srid))
   ([^String geojson srid]
    (-> geojson
        parse-geojson
        read-geometry
        (jts/set-srid srid))))
 
-(defn to-geojson [shapelike] (.toString (.write (GeoJSONWriter.) (to-jts shapelike jts/default-srid))))
+(defn to-geojson [shapelike] (.toString (.write (GeoJSONWriter.) (to-jts shapelike crs/default-srid))))
 
 (defn- ^Feature gj-feature
   [{shapelike :geometry properties :properties}]
-  (let [gj-geom (.write (GeoJSONWriter.) (to-jts shapelike jts/default-srid))]
+  (let [gj-geom (.write (GeoJSONWriter.) (to-jts shapelike crs/default-srid))]
     (Feature. gj-geom (stringify-keys properties))))
 
 (defn to-geojson-feature

--- a/src/geo/jts.clj
+++ b/src/geo/jts.clj
@@ -21,17 +21,19 @@
                                       PrecisionModel)
            (org.locationtech.proj4j CoordinateTransform ProjCoordinate)))
 
-(def ^PrecisionModel pm crs/pm) ; Deprecated as of 3.0.2
-(def ^GeometryFactory gf crs/get-geometry-factory) ; Deprecated as of 3.0.2
-(def default-srid crs/default-srid) ; Deprecated as of 3.0.2
-(def ^GeometryFactory gf-wgs84 crs/gf-wgs84); Deprecated as of 3.0.2
-(def ^GeometryFactory get-factory crs/get-geometry-factory) ; Deprecated as of 3.0.2
-(def get-srid crs/get-srid) ; Deprecated as of 3.0.2
+(def ^PrecisionModel pm crs/pm) ; Deprecated as of 3.1.0
+(def ^GeometryFactory gf crs/get-geometry-factory) ; Deprecated as of 3.1.0
+(def default-srid crs/default-srid) ; Deprecated as of 3.1.0
+(def ^GeometryFactory gf-wgs84 crs/gf-wgs84); Deprecated as of 3.1.0
+(def ^GeometryFactory get-factory crs/get-geometry-factory) ; Deprecated as of 3.1.0
+(def get-srid crs/get-srid) ; Deprecated as of 3.1.0
 
 (defn set-srid
   "Sets a geometry's SRID to a new value, and returns that geometry."
   [^Geometry geom srid]
-  (.createGeometry (crs/get-geometry-factory srid) geom))
+  (if (= (crs/get-srid geom) (crs/get-srid srid))
+      geom
+      (.createGeometry (crs/get-geometry-factory srid) geom)))
 
 (defn coordinate
   "Creates a Coordinate."
@@ -202,7 +204,7 @@
   (.createMultiPolygon (crs/get-geometry-factory (first polygons))
                        (polygon-array polygons)))
 
-; Deprecated since 3.0.2.
+; Deprecated since 3.1.0.
 (defn polygons
   "Given a MultiPolygon, generate a sequence of Polygons.
   Deprecated in favor of more general geometries function."

--- a/src/geo/jts.clj
+++ b/src/geo/jts.clj
@@ -60,7 +60,7 @@
   ([^Coordinate coordinate]
    (.createPoint crs/gf-wgs84 coordinate))
   ([lat long]
-   (point long lat crs/default-srid))
+   (point long lat crs/gf-wgs84))
   ([x y srid]
    (.createPoint (crs/get-geometry-factory srid) ^Coordinate (coordinate x y))))
 
@@ -204,7 +204,7 @@
 
    Allows an optional SRID argument at end."
   ([rings]
-   (polygon-wkt rings crs/default-srid))
+   (polygon-wkt rings crs/gf-wgs84))
   ([rings srid]
    (let [rings (map #(linear-ring-wkt % srid) rings)]
      (polygon (first rings) (into-array LinearRing (rest rings))))))

--- a/src/geo/jts.clj
+++ b/src/geo/jts.clj
@@ -21,12 +21,23 @@
                                       PrecisionModel)
            (org.locationtech.proj4j CoordinateTransform ProjCoordinate)))
 
-(def ^PrecisionModel pm crs/pm) ; Deprecated as of 3.1.0
-(def ^GeometryFactory gf crs/get-geometry-factory) ; Deprecated as of 3.1.0
-(def default-srid crs/default-srid) ; Deprecated as of 3.1.0
-(def ^GeometryFactory gf-wgs84 crs/gf-wgs84); Deprecated as of 3.1.0
-(def ^GeometryFactory get-factory crs/get-geometry-factory) ; Deprecated as of 3.1.0
-(def get-srid crs/get-srid) ; Deprecated as of 3.1.0
+(def ^PrecisionModel pm ; Deprecated as of 3.1.0
+  "Deprecated as of 3.1.0, in favor of geo.crs/pm." crs/pm)
+(def ^GeometryFactory gf ; Deprecated as of 3.1.0
+  "Deprecated as of 3.1.0, in favor of geo.crs/get-geometry-factory."
+  crs/get-geometry-factory)
+(def default-srid ; Deprecated as of 3.1.0
+  "Deprecated as of 3.1.0, in favor of geo.crs/default-srid."
+  crs/default-srid)
+(def ^GeometryFactory gf-wgs84 ; Deprecated as of 3.1.0
+  "Deprecated as of 3.1.0, in favor of geo.crs/gf-wgs84."
+  crs/gf-wgs84)
+(def ^GeometryFactory get-factory ; Deprecated as of 3.1.0
+  "Deprecated as of 3.1.0, in favor of geo.crs/get-geometry-factory."
+  crs/get-geometry-factory)
+(def get-srid ; Deprecated as of 3.1.0
+  "Deprecated as of 3.1.0, in favor of geo.crs/get-srid."
+  crs/get-srid)
 
 (defn set-srid
   "Sets a geometry's SRID to a new value, and returns that geometry."
@@ -207,7 +218,7 @@
 ; Deprecated since 3.1.0.
 (defn polygons
   "Given a MultiPolygon, generate a sequence of Polygons.
-  Deprecated in favor of more general geometries function."
+  Deprecated since 3.1.0, in favor of geo.jts/geometries."
   [^MultiPolygon m]
   (geometries m))
 

--- a/src/geo/jts.clj
+++ b/src/geo/jts.clj
@@ -322,10 +322,10 @@
   CoordinateTransform from the two Transformables and use the supplied GeometryFactory for the
   target SRID."
   ([g t]
-   ;; t is either a Transform or a Transformable
+   ;; t is either a CoordinateTransform or a Transformable
    (if (instance? CoordinateTransform t)
          ; If t is CoordinateTransform
-         (tf g t (crs/get-target-crs t))
+         (transform-geom g t (crs/get-target-crs t))
          ; If t is Transformable, make sure that g has a source CRS
          (do
            (assert (geom-srid? g)

--- a/src/geo/jts.clj
+++ b/src/geo/jts.clj
@@ -293,7 +293,7 @@
          (transform-geom g t (crs/get-geometry-factory t))))
   ([g c1 c2]
    (cond (instance? CoordinateTransform c1)
-         (transform-geom g c1 c2 (crs/get-geometry-factory c2))
+         (tf g c1 (crs/get-geometry-factory c2))
          (and (satisfies? Transformable c1)
               (instance? GeometryFactory c2))
          (let [geom-srid (crs/get-srid g)]
@@ -303,9 +303,9 @@
              g
              (transform-geom g geom-srid c1 c2)))
          :else
-         (tf g (crs/create-transform c1 c2))))
+         (transform-geom g (crs/create-transform c1 c2))))
   ([g c1 c2 geometry-factory]
-   (tf g (crs/create-transform c1 c2) geometry-factory)))
+   (transform-geom g (crs/create-transform c1 c2) geometry-factory)))
 
 (defn ^Point centroid
   "Get the centroid of a JTS object."

--- a/src/geo/jts.clj
+++ b/src/geo/jts.clj
@@ -283,42 +283,80 @@
     (isGeometryChanged [_]
       true)))
 
+(defn- geom-srid?
+  "Check if a Geometry has a valid SRID."
+  [g]
+  (let [geom-srid (crs/get-srid g)]
+    (and (not= 0 geom-srid)
+         (not (nil? geom-srid)))))
+
 (defn- tf
   "Transform a Geometry by applying CoordinateTransform to the Geometry.
   When the target CRS has an SRID, set the geometry's SRID to that."
-  ([^Geometry g ^CoordinateTransform transform]
-   (tf g transform (crs/get-target-crs transform)))
-  ([^Geometry g ^CoordinateTransform transform ^GeometryFactory gf]
-   (let [g (.copy g)]
-     (.apply g (transform-coord-seq-filter transform))
-     (set-srid g gf))))
+  [^Geometry g ^CoordinateTransform transform ^GeometryFactory gf]
+  (let [g (.copy g)]
+    (.apply g (transform-coord-seq-filter transform))
+    (set-srid g gf)))
 
 (defn transform-geom
   "Transform a Geometry.
-  When a single CoordinateTransform is passed, apply that transform to the Geometry. When the target CRS
-  has an SRID, set the geometry's SRID to that. When a single Transformable target is passed, attempt to
-  find the geometry's CRS to generate and apply a CoordinateTransform. When two CRSs are passed as
-  arguments, generate a CoordinateTransform and apply accordingly. If the final argument is a
-  GeometryFactory, use that in the transformation."
+  When a Geometry and CoordinateTransform is passed, apply that transform to the Geometry.
+
+  When a Geometry and Transformable is passed, attempt to transform the Geometry to that target.
+
+  When a Geometry, CoordinateTransform, and Transformable are passed, apply the CoordinateTransform
+  and get a GeometryFactory from the transformable.
+
+  When a Geometry, Transformable, and GeometryFactory are passed, and the Geometry has an SRID,
+  take the Transformable as a target CRS, create a CoordinateTransform,
+  and use the GeometryFactory for a target SRID.
+
+  When a Geometry, Transformable, and GeometryFactory are passed, and the Geometry has no SRID,
+  take the Transformable as a source CRS and the GeometryFactory as a target CRS,
+  create a corresponding Transform, and use the GeometryFactory for a target SRID.
+
+  When a Geometry, Transformable, and Transformable are passed, create a CoordinateTransform and
+  get a GeometryFactory from the target Transformable.
+
+  When a Geometry, Transformable, Transformable, and GeometryFactory are all passed, create a
+  CoordinateTransform from the two Transformables and use the supplied GeometryFactory for the
+  target SRID."
   ([g t]
+   ;; t is either a Transform or a Transformable
    (if (instance? CoordinateTransform t)
-         (tf g t)
-         (transform-geom g t (crs/get-geometry-factory t))))
+         ; If t is CoordinateTransform
+         (tf g t (crs/get-target-crs t))
+         ; If t is Transformable, make sure that g has a source CRS
+         (do
+           (assert (geom-srid? g)
+                   "Geometry must have a valid source SRID to generate a transform to a target.")
+           (transform-geom g t (crs/get-geometry-factory t)))))
   ([g c1 c2]
-   (cond (instance? CoordinateTransform c1)
-         (tf g c1 (crs/get-geometry-factory c2))
-         (and (satisfies? Transformable c1)
-              (instance? GeometryFactory c2))
-         (let [geom-srid (crs/get-srid g)]
-           (assert (not= 0 geom-srid)
-                   "Geometry must have a valid SRID to be transformed")
-           (if (= (crs/get-srid c1) geom-srid)
-             g
-             (transform-geom g geom-srid c1 c2)))
-         :else
-         (transform-geom g (crs/create-transform c1 c2))))
+   ;; c1 is either a CoordinateTransform or Transformable
+   ;; c2 is either a Transformable or a GeometryFactory
+   (cond
+     ;; If c1 is a CoordinateTransform, assume c2 acts as a GeometryFactory
+     (instance? CoordinateTransform c1)
+     (tf g c1 (crs/get-geometry-factory c2))
+     ;; If c1 is Transformable, c2 is GeometryFactory, and g has SRID,
+     ;; take c1 as a target CRS, create the relevant Transform, and apply the Factory
+     ;; as the target SRID.
+     ;; If c1 is Transformable, c2 is GeometryFactory, and g does not have SRID,
+     ;; then take c1 as the source CRS and get the target CRS from the factory.
+     (and (satisfies? Transformable c1)
+          (instance? GeometryFactory c2))
+       (if (geom-srid? g)
+         (transform-geom g (crs/get-srid g) c1 c2)
+         (transform-geom g c1 (crs/get-srid c2) c2))
+   ;; Otherwise, c1 and c2 are both Transformable, and create transform
+   :else
+   (transform-geom g (crs/create-transform c1 c2) (crs/get-geometry-factory c2))))
   ([g c1 c2 geometry-factory]
-   (transform-geom g (crs/create-transform c1 c2) geometry-factory)))
+   ;; When c1, c2, and geometry-factory are all provided,
+   ;; create a transform and use the supplied factory
+   (if (= (crs/get-srid c1) (crs/get-srid c2))
+     (set-srid g geometry-factory)
+     (transform-geom g (crs/create-transform c1 c2) geometry-factory))))
 
 (defn ^Point centroid
   "Get the centroid of a JTS object."

--- a/src/geo/spatial.clj
+++ b/src/geo/spatial.clj
@@ -99,26 +99,26 @@
 
   RectangleImpl
   (to-shape [this] this)
-  (to-jts ([this] (jts/set-srid (.getGeom ^JtsGeometry this) crs/default-srid))
+  (to-jts ([this] (jts/set-srid (.getGeom ^JtsGeometry this) crs/gf-wgs84))
           ([this srid] (to-jts (to-jts this) srid)))
 
   PointImpl
   (to-shape [this] this)
-  (to-jts ([this] (jts/set-srid (jts-point (.getY this) (.getX this)) crs/default-srid))
+  (to-jts ([this] (jts/set-srid (jts-point (.getY this) (.getX this)) crs/gf-wgs84))
           ([this srid] (to-jts (to-jts this) srid)))
 
   JtsGeometry
   (to-shape [this] this)
-  (to-jts ([this] (jts/set-srid (.getGeom this) crs/default-srid))
+  (to-jts ([this] (jts/set-srid (.getGeom this) crs/gf-wgs84))
           ([this srid] (to-jts (to-jts this) srid)))
 
   JtsPoint
   (to-shape [this] this)
-  (to-jts ([this] (jts/set-srid (jts-point (.getY this) (.getX this)) crs/default-srid))
+  (to-jts ([this] (jts/set-srid (jts-point (.getY this) (.getX this)) crs/gf-wgs84))
           ([this srid] (to-jts (to-jts this) srid)))
 
   Geometry
-  (to-shape [this] (JtsGeometry. (jts/transform-geom this crs/default-srid) earth true true))
+  (to-shape [this] (JtsGeometry. (jts/transform-geom this crs/gf-wgs84) earth true true))
   (to-jts ([this] this)
           ([this srid] (jts/transform-geom this srid)))
 
@@ -143,8 +143,8 @@
   (to-h3-point [this] (h3-point this))
 
   org.locationtech.jts.geom.Point
-  (latitude [this] (.getY ^org.locationtech.jts.geom.Point (jts/transform-geom this crs/default-srid)))
-  (longitude [this] (.getX ^org.locationtech.jts.geom.Point (jts/transform-geom this crs/default-srid)))
+  (latitude [this] (.getY ^org.locationtech.jts.geom.Point (jts/transform-geom this crs/gf-wgs84)))
+  (longitude [this] (.getX ^org.locationtech.jts.geom.Point (jts/transform-geom this crs/gf-wgs84)))
   (to-spatial4j-point [this] (spatial4j-point this))
   (to-geohash-point [this] (geohash-point this))
   (to-h3-point [this] (h3-point this))

--- a/src/geo/spatial.clj
+++ b/src/geo/spatial.clj
@@ -103,7 +103,7 @@
   RectangleImpl
   (to-shape [this] this)
   (to-jts
-    ([this] (jts/set-srid (.getGeom ^JtsGeometry this) crs/gf-wgs84))
+    ([this] (crs/set-srid (.getGeom ^JtsGeometry this) crs/gf-wgs84))
     ([this srid] (to-jts (to-jts this) srid))
     ([this c1 c2] (to-jts (to-jts this) c1 c2))
     ([this c1 c2 geometry-factory]
@@ -112,7 +112,7 @@
   PointImpl
   (to-shape [this] this)
   (to-jts
-    ([this] (jts/set-srid (jts-point (.getY this) (.getX this)) crs/gf-wgs84))
+    ([this] (crs/set-srid (jts-point (.getY this) (.getX this)) crs/gf-wgs84))
     ([this srid] (to-jts (to-jts this) srid))
     ([this c1 c2] (to-jts (to-jts this) c1 c2))
     ([this c1 c2 geometry-factory] (to-jts (to-jts this) c1 c2 geometry-factory)))
@@ -120,7 +120,7 @@
   JtsGeometry
   (to-shape [this] this)
   (to-jts
-    ([this] (jts/set-srid (.getGeom this) crs/gf-wgs84))
+    ([this] (crs/set-srid (.getGeom this) crs/gf-wgs84))
     ([this srid] (to-jts (to-jts this) srid))
     ([this c1 c2] (to-jts (to-jts this) c1 c2))
     ([this c1 c2 geometry-factory] (to-jts (to-jts this) c1 c2 geometry-factory)))
@@ -128,25 +128,25 @@
   JtsPoint
   (to-shape [this] this)
   (to-jts
-    ([this] (jts/set-srid (jts-point (.getY this) (.getX this)) crs/gf-wgs84))
+    ([this] (crs/set-srid (jts-point (.getY this) (.getX this)) crs/gf-wgs84))
     ([this srid] (to-jts (to-jts this) srid))
     ([this c1 c2] (to-jts (to-jts this) c1 c2))
     ([this c1 c2 geometry-factory] (to-jts (to-jts this) c1 c2 geometry-factory)))
 
   Geometry
-  (to-shape [this] (JtsGeometry. (jts/transform-geom this crs/gf-wgs84) earth true true))
+  (to-shape [this] (JtsGeometry. (crs/transform-geom this crs/gf-wgs84) earth true true))
   (to-jts
     ([this] this)
-    ([this srid] (jts/transform-geom this srid))
-    ([this c1 c2] (jts/transform-geom this c1 c2))
+    ([this srid] (crs/transform-geom this srid))
+    ([this c1 c2] (crs/transform-geom this c1 c2))
     ([this c1 c2 geometry-factory]
-     (jts/transform-geom this c1 c2 geometry-factory)))
+     (crs/transform-geom this c1 c2 geometry-factory)))
 
   GeoCoord
   (to-shape [this] (spatial4j-point this))
   (to-jts
     ([this] (jts-point this))
-    ([this srid] (jts/transform-geom (to-jts this) srid))
+    ([this srid] (crs/transform-geom (to-jts this) srid))
     ([this c1 c2] (to-jts (to-jts this) c1 c2))
     ([this c1 c2 geometry-factory] (to-jts (to-jts this) c1 c2 geometry-factory))))
 
@@ -166,8 +166,10 @@
   (to-h3-point [this] (h3-point this))
 
   org.locationtech.jts.geom.Point
-  (latitude [this] (.getY ^org.locationtech.jts.geom.Point (jts/transform-geom this crs/gf-wgs84)))
-  (longitude [this] (.getX ^org.locationtech.jts.geom.Point (jts/transform-geom this crs/gf-wgs84)))
+  (latitude [this] (.getY ^org.locationtech.jts.geom.Point
+                          (crs/transform-geom this crs/gf-wgs84)))
+  (longitude [this] (.getX ^org.locationtech.jts.geom.Point
+                           (crs/transform-geom this crs/gf-wgs84)))
   (to-spatial4j-point [this] (spatial4j-point this))
   (to-geohash-point [this] (geohash-point this))
   (to-h3-point [this] (h3-point this))
@@ -452,7 +454,7 @@
    Length of individual segments may vary a bit but total length should remain the same."
   [linestring segment-length]
   (let [srid (crs/get-srid linestring)]
-    (map #(jts/transform-geom % srid) (resegment-wgs84 (jts/transform-geom linestring 4326) segment-length))))
+    (map #(crs/transform-geom % srid) (resegment-wgs84 (crs/transform-geom linestring 4326) segment-length))))
 
 (def ^DistanceCalculator vincenty-distance-calculator (org.locationtech.spatial4j.distance.GeodesicSphereDistCalc$Vincenty.))
 

--- a/src/geo/spatial.clj
+++ b/src/geo/spatial.clj
@@ -89,43 +89,58 @@
 
 (defprotocol Shapelike
   (^Shape to-shape [this] "Convert anything to a Shape.")
-  (^Geometry to-jts [this] [this srid] "Convert anything to a projected JTS Geometry."))
+  (^Geometry to-jts [this] [this srid] [this c1 c2] [this c1 c2 geometry-factory]
+   "Convert anything to a projected JTS Geometry. See geo.jts/transform-geom for argument information."))
 
 (extend-protocol Shapelike
   GeoCircle
   (to-shape [this] this)
   (to-jts ([_] (throw (Exception. "Cannot cast GeoCircle to JTS.")))
-          ([_ _] (throw (Exception. "Cannot cast GeoCircle to JTS."))))
+          ([_ _] (throw (Exception. "Cannot cast GeoCircle to JTS.")))
+          ([_ _ _] (throw (Exception. "Cannot cast GeoCircle to JTS.")))
+          ([_ _ _ _] (throw (Exception. "Cannot cast GeoCircle to JTS."))))
 
   RectangleImpl
   (to-shape [this] this)
   (to-jts ([this] (jts/set-srid (.getGeom ^JtsGeometry this) crs/gf-wgs84))
-          ([this srid] (to-jts (to-jts this) srid)))
+          ([this srid] (to-jts (to-jts this) srid))
+          ([this c1 c2] (to-jts (to-jts this) c1 c2))
+          ([this c1 c2 geometry-factory] (to-jts (to-jts this) c1 c2 geometry-factory)))
 
   PointImpl
   (to-shape [this] this)
   (to-jts ([this] (jts/set-srid (jts-point (.getY this) (.getX this)) crs/gf-wgs84))
-          ([this srid] (to-jts (to-jts this) srid)))
+          ([this srid] (to-jts (to-jts this) srid))
+          ([this c1 c2] (to-jts (to-jts this) c1 c2))
+          ([this c1 c2 geometry-factory] (to-jts (to-jts this) c1 c2 geometry-factory)))
 
   JtsGeometry
   (to-shape [this] this)
   (to-jts ([this] (jts/set-srid (.getGeom this) crs/gf-wgs84))
-          ([this srid] (to-jts (to-jts this) srid)))
+          ([this srid] (to-jts (to-jts this) srid))
+          ([this c1 c2] (to-jts (to-jts this) c1 c2))
+          ([this c1 c2 geometry-factory] (to-jts (to-jts this) c1 c2 geometry-factory)))
 
   JtsPoint
   (to-shape [this] this)
   (to-jts ([this] (jts/set-srid (jts-point (.getY this) (.getX this)) crs/gf-wgs84))
-          ([this srid] (to-jts (to-jts this) srid)))
+          ([this srid] (to-jts (to-jts this) srid))
+          ([this c1 c2] (to-jts (to-jts this) c1 c2))
+          ([this c1 c2 geometry-factory] (to-jts (to-jts this) c1 c2 geometry-factory)))
 
   Geometry
   (to-shape [this] (JtsGeometry. (jts/transform-geom this crs/gf-wgs84) earth true true))
   (to-jts ([this] this)
-          ([this srid] (jts/transform-geom this srid)))
+          ([this srid] (jts/transform-geom this srid))
+          ([this c1 c2] (jts/transform-geom this c1 c2))
+          ([this c1 c2 geometry-factory] (jts/transform-geom this c1 c2)))
 
   GeoCoord
   (to-shape [this] (spatial4j-point this))
   (to-jts ([this] (jts-point this))
-          ([this srid] (jts/transform-geom (to-jts this) srid))))
+          ([this srid] (jts/transform-geom (to-jts this) srid))
+          ([this c1 c2] (to-jts (to-jts this) c1 c2))
+          ([this c1 c2 geometry-factory] (to-jts (to-jts this) c1 c2 geometry-factory))))
 
 (defprotocol Point
   (latitude [this])

--- a/src/geo/spatial.clj
+++ b/src/geo/spatial.clj
@@ -16,7 +16,8 @@
   compute relationships between shapes: their intersections, contains, disjoint
   statuses, etc."
   (:use [clojure.math.numeric-tower :only [abs]])
-  (:require [geo.jts :as jts])
+  (:require [geo.crs :as crs]
+            [geo.jts :as jts])
   (:import (ch.hsr.geohash WGS84Point)
            (ch.hsr.geohash.util VincentyGeodesy)
            (com.uber.h3core.util GeoCoord)
@@ -98,26 +99,26 @@
 
   RectangleImpl
   (to-shape [this] this)
-  (to-jts ([this] (jts/set-srid (.getGeom ^JtsGeometry this) jts/default-srid))
+  (to-jts ([this] (jts/set-srid (.getGeom ^JtsGeometry this) crs/default-srid))
           ([this srid] (to-jts (to-jts this) srid)))
 
   PointImpl
   (to-shape [this] this)
-  (to-jts ([this] (jts/set-srid (jts-point (.getY this) (.getX this)) jts/default-srid))
+  (to-jts ([this] (jts/set-srid (jts-point (.getY this) (.getX this)) crs/default-srid))
           ([this srid] (to-jts (to-jts this) srid)))
 
   JtsGeometry
   (to-shape [this] this)
-  (to-jts ([this] (jts/set-srid (.getGeom this) jts/default-srid))
+  (to-jts ([this] (jts/set-srid (.getGeom this) crs/default-srid))
           ([this srid] (to-jts (to-jts this) srid)))
 
   JtsPoint
   (to-shape [this] this)
-  (to-jts ([this] (jts/set-srid (jts-point (.getY this) (.getX this)) jts/default-srid))
+  (to-jts ([this] (jts/set-srid (jts-point (.getY this) (.getX this)) crs/default-srid))
           ([this srid] (to-jts (to-jts this) srid)))
 
   Geometry
-  (to-shape [this] (JtsGeometry. (jts/transform-geom this jts/default-srid) earth true true))
+  (to-shape [this] (JtsGeometry. (jts/transform-geom this crs/default-srid) earth true true))
   (to-jts ([this] this)
           ([this srid] (jts/transform-geom this srid)))
 
@@ -142,8 +143,8 @@
   (to-h3-point [this] (h3-point this))
 
   org.locationtech.jts.geom.Point
-  (latitude [this] (.getY ^org.locationtech.jts.geom.Point (jts/transform-geom this jts/default-srid)))
-  (longitude [this] (.getX ^org.locationtech.jts.geom.Point (jts/transform-geom this jts/default-srid)))
+  (latitude [this] (.getY ^org.locationtech.jts.geom.Point (jts/transform-geom this crs/default-srid)))
+  (longitude [this] (.getX ^org.locationtech.jts.geom.Point (jts/transform-geom this crs/default-srid)))
   (to-spatial4j-point [this] (spatial4j-point this))
   (to-geohash-point [this] (geohash-point this))
   (to-h3-point [this] (h3-point this))
@@ -427,7 +428,7 @@
    provided length (in meters). Final segment may be less than the requested length.
    Length of individual segments may vary a bit but total length should remain the same."
   [linestring segment-length]
-  (let [srid (jts/get-srid linestring)]
+  (let [srid (crs/get-srid linestring)]
     (map #(jts/transform-geom % srid) (resegment-wgs84 (jts/transform-geom linestring 4326) segment-length))))
 
 (def ^DistanceCalculator vincenty-distance-calculator (org.locationtech.spatial4j.distance.GeodesicSphereDistCalc$Vincenty.))

--- a/src/geo/spatial.clj
+++ b/src/geo/spatial.clj
@@ -102,45 +102,53 @@
 
   RectangleImpl
   (to-shape [this] this)
-  (to-jts ([this] (jts/set-srid (.getGeom ^JtsGeometry this) crs/gf-wgs84))
-          ([this srid] (to-jts (to-jts this) srid))
-          ([this c1 c2] (to-jts (to-jts this) c1 c2))
-          ([this c1 c2 geometry-factory] (to-jts (to-jts this) c1 c2 geometry-factory)))
+  (to-jts
+    ([this] (jts/set-srid (.getGeom ^JtsGeometry this) crs/gf-wgs84))
+    ([this srid] (to-jts (to-jts this) srid))
+    ([this c1 c2] (to-jts (to-jts this) c1 c2))
+    ([this c1 c2 geometry-factory]
+     (to-jts (to-jts this) c1 c2 geometry-factory)))
 
   PointImpl
   (to-shape [this] this)
-  (to-jts ([this] (jts/set-srid (jts-point (.getY this) (.getX this)) crs/gf-wgs84))
-          ([this srid] (to-jts (to-jts this) srid))
-          ([this c1 c2] (to-jts (to-jts this) c1 c2))
-          ([this c1 c2 geometry-factory] (to-jts (to-jts this) c1 c2 geometry-factory)))
+  (to-jts
+    ([this] (jts/set-srid (jts-point (.getY this) (.getX this)) crs/gf-wgs84))
+    ([this srid] (to-jts (to-jts this) srid))
+    ([this c1 c2] (to-jts (to-jts this) c1 c2))
+    ([this c1 c2 geometry-factory] (to-jts (to-jts this) c1 c2 geometry-factory)))
 
   JtsGeometry
   (to-shape [this] this)
-  (to-jts ([this] (jts/set-srid (.getGeom this) crs/gf-wgs84))
-          ([this srid] (to-jts (to-jts this) srid))
-          ([this c1 c2] (to-jts (to-jts this) c1 c2))
-          ([this c1 c2 geometry-factory] (to-jts (to-jts this) c1 c2 geometry-factory)))
+  (to-jts
+    ([this] (jts/set-srid (.getGeom this) crs/gf-wgs84))
+    ([this srid] (to-jts (to-jts this) srid))
+    ([this c1 c2] (to-jts (to-jts this) c1 c2))
+    ([this c1 c2 geometry-factory] (to-jts (to-jts this) c1 c2 geometry-factory)))
 
   JtsPoint
   (to-shape [this] this)
-  (to-jts ([this] (jts/set-srid (jts-point (.getY this) (.getX this)) crs/gf-wgs84))
-          ([this srid] (to-jts (to-jts this) srid))
-          ([this c1 c2] (to-jts (to-jts this) c1 c2))
-          ([this c1 c2 geometry-factory] (to-jts (to-jts this) c1 c2 geometry-factory)))
+  (to-jts
+    ([this] (jts/set-srid (jts-point (.getY this) (.getX this)) crs/gf-wgs84))
+    ([this srid] (to-jts (to-jts this) srid))
+    ([this c1 c2] (to-jts (to-jts this) c1 c2))
+    ([this c1 c2 geometry-factory] (to-jts (to-jts this) c1 c2 geometry-factory)))
 
   Geometry
   (to-shape [this] (JtsGeometry. (jts/transform-geom this crs/gf-wgs84) earth true true))
-  (to-jts ([this] this)
-          ([this srid] (jts/transform-geom this srid))
-          ([this c1 c2] (jts/transform-geom this c1 c2))
-          ([this c1 c2 geometry-factory] (jts/transform-geom this c1 c2)))
+  (to-jts
+    ([this] this)
+    ([this srid] (jts/transform-geom this srid))
+    ([this c1 c2] (jts/transform-geom this c1 c2))
+    ([this c1 c2 geometry-factory]
+     (jts/transform-geom this c1 c2 geometry-factory)))
 
   GeoCoord
   (to-shape [this] (spatial4j-point this))
-  (to-jts ([this] (jts-point this))
-          ([this srid] (jts/transform-geom (to-jts this) srid))
-          ([this c1 c2] (to-jts (to-jts this) c1 c2))
-          ([this c1 c2 geometry-factory] (to-jts (to-jts this) c1 c2 geometry-factory))))
+  (to-jts
+    ([this] (jts-point this))
+    ([this srid] (jts/transform-geom (to-jts this) srid))
+    ([this c1 c2] (to-jts (to-jts this) c1 c2))
+    ([this c1 c2 geometry-factory] (to-jts (to-jts this) c1 c2 geometry-factory))))
 
 (defprotocol Point
   (latitude [this])

--- a/test/geo/t_crs.clj
+++ b/test/geo/t_crs.clj
@@ -42,8 +42,10 @@
                                                    "+proj=longlat +a=6376896 +b=6355834.846687363 +no_defs")
                    src (sut/get-source-crs transform)
                    target (sut/get-target-crs transform)]
-               (into [] (.getParameters src)) => ["+proj=longlat" "+a=6378270" "+b=6356794.343434343" "+no_defs"]
-               (into [] (.getParameters target)) => ["+proj=longlat" "+a=6376896" "+b=6355834.846687363" "+no_defs"]
+               (into [] (sut/get-parameters src)) => ["+proj=longlat" "+a=6378270" "+b=6356794.343434343" "+no_defs"]
+               (into [] (sut/get-parameters target)) => ["+proj=longlat" "+a=6376896" "+b=6355834.846687363" "+no_defs"]
+               (sut/get-parameter-string src) => "+proj=longlat +a=6378270 +b=6356794.343434343 +no_defs "
+               (sut/get-parameter-string target) => "+proj=longlat +a=6376896 +b=6355834.846687363 +no_defs "
                (sut/get-name src) => ""
                (sut/get-name target) => "")))
 

--- a/test/geo/t_crs.clj
+++ b/test/geo/t_crs.clj
@@ -1,5 +1,6 @@
 (ns geo.t-crs
   (:require [geo.crs :as sut]
+            [geo.jts :as jts]
             [midje.sweet :as m :refer [fact facts]]))
 
 (facts "Identifying and converting EPSG and SRID identifiers"
@@ -45,3 +46,19 @@
                (into [] (.getParameters target)) => ["+proj=longlat" "+a=6376896" "+b=6355834.846687363" "+no_defs"]
                (sut/get-name src) => ""
                (sut/get-name target) => "")))
+
+(facts "Transformable"
+       (fact "Testing geometry factories"
+             (let [transform (sut/create-transform 4326 2000)
+                   src (sut/get-source-crs transform)
+                   target (sut/get-target-crs transform)
+                   gf1 (sut/get-geometry-factory src)
+                   gf2 (sut/get-geometry-factory target)
+                   g1 (jts/point 0 0 gf1)
+                   g2 (jts/point 0 0 gf2)]
+               (sut/get-srid gf1) => 4326
+               (sut/get-srid gf2) => 2000
+               (sut/get-srid g1) => 4326
+               (sut/get-srid g2) => 2000
+               (sut/get-srid (sut/get-geometry-factory g1)) => 4326
+               (sut/get-srid (sut/get-geometry-factory g2)) => 2000)))

--- a/test/geo/t_geohash.clj
+++ b/test/geo/t_geohash.clj
@@ -1,5 +1,6 @@
 (ns geo.t-geohash
-  (:require [geo.spatial :as spatial]
+  (:require [geo.crs :as crs]
+            [geo.spatial :as spatial]
             [geo.jts :as jts]
             [geo.io :as gio]
             [geo.geohash :refer :all]
@@ -207,9 +208,9 @@
        (let [gh (geohash "9q5")
              points [[-119.53125 33.75, -119.53125 35.15625, -118.125 35.15625, -118.125 33.75, -119.53125 33.75]]]
          (bbox-geom gh) => (jts/polygon-wkt points)
-         (jts/get-srid (bbox-geom gh)) => 4326
-         (jts/get-srid (spatial/to-jts gh)) => 4326
-         (jts/get-srid (spatial/to-jts gh 1234)) => 1234))
+         (crs/get-srid (bbox-geom gh)) => 4326
+         (crs/get-srid (spatial/to-jts gh)) => 4326
+         (crs/get-srid (spatial/to-jts gh 1234)) => 1234))
 
 (facts "Getting bounding Shapes for geohashes"
        (let [gh (geohash "9q5")]

--- a/test/geo/t_geohash.clj
+++ b/test/geo/t_geohash.clj
@@ -210,7 +210,7 @@
          (bbox-geom gh) => (jts/polygon-wkt points)
          (crs/get-srid (bbox-geom gh)) => 4326
          (crs/get-srid (spatial/to-jts gh)) => 4326
-         (crs/get-srid (spatial/to-jts gh 1234)) => 1234))
+         (crs/get-srid (spatial/to-jts gh 3586)) => 3586))
 
 (facts "Getting bounding Shapes for geohashes"
        (let [gh (geohash "9q5")]

--- a/test/geo/t_h3.clj
+++ b/test/geo/t_h3.clj
@@ -1,5 +1,6 @@
 (ns geo.t-h3
-  (:require [geo.h3 :as sut]
+  (:require [geo.crs :as crs]
+            [geo.h3 :as sut]
             [geo.geohash :as geohash]
             [geo.io :as io]
             [geo.jts :as jts]
@@ -10,7 +11,7 @@
 
 (def geohash-with-hole (jts/set-srid (.difference (spatial/to-jts (geohash/geohash "u4pruy"))
                                                   (spatial/to-jts (geohash/geohash "u4pruyk")))
-                                     jts/default-srid))
+                                     crs/default-srid))
 (def h3-example-str "871f24ac5ffffff")
 (def h3-example-long 608533827635118079)
 (def h3-example-latitude 57.64911063015461)

--- a/test/geo/t_h3.clj
+++ b/test/geo/t_h3.clj
@@ -11,7 +11,7 @@
 
 (def geohash-with-hole (jts/set-srid (.difference (spatial/to-jts (geohash/geohash "u4pruy"))
                                                   (spatial/to-jts (geohash/geohash "u4pruyk")))
-                                     crs/default-srid))
+                                     crs/gf-wgs84))
 (def h3-example-str "871f24ac5ffffff")
 (def h3-example-long 608533827635118079)
 (def h3-example-latitude 57.64911063015461)

--- a/test/geo/t_io.clj
+++ b/test/geo/t_io.clj
@@ -1,5 +1,6 @@
 (ns geo.t-io
   (:require [clojure.string :refer [trim]]
+            [geo.crs :as crs]
             [geo.io :as sut]
             [geo.jts :as jts]
             [cheshire.core :as json]
@@ -72,16 +73,16 @@
              (-> wkt-2 sut/read-wkt (jts/set-srid 3857) sut/to-wkb-hex) => wkb-2-hex))
 
 (fact "understands projection in hex string"
-      (-> wkb-hex sut/read-wkb-hex jts/get-srid) => 4326
-      (-> ewkb-hex-wgs84 sut/read-wkb-hex jts/get-srid) => 4326
-      (-> wkb-2-hex sut/read-wkb-hex jts/get-srid) => 4326
-      (-> ewkb-2-hex-wgs84 sut/read-wkb-hex jts/get-srid) => 4326)
+      (-> wkb-hex sut/read-wkb-hex crs/get-srid) => 4326
+      (-> ewkb-hex-wgs84 sut/read-wkb-hex crs/get-srid) => 4326
+      (-> wkb-2-hex sut/read-wkb-hex crs/get-srid) => 4326
+      (-> ewkb-2-hex-wgs84 sut/read-wkb-hex crs/get-srid) => 4326)
 
 (fact "reads WKTs and WKBs with custom SRID"
-      (-> wkt sut/read-wkt jts/get-srid) => 4326
-      (-> wkt (sut/read-wkt 2229) jts/get-srid) => 2229
-      (-> wkb-hex sut/read-wkb-hex jts/get-srid) => 4326
-      (-> wkb-hex (sut/read-wkb-hex 2229) jts/get-srid) => 2229)
+      (-> wkt sut/read-wkt crs/get-srid) => 4326
+      (-> wkt (sut/read-wkt 2229) crs/get-srid) => 2229
+      (-> wkb-hex sut/read-wkb-hex crs/get-srid) => 4326
+      (-> wkb-hex (sut/read-wkb-hex 2229) crs/get-srid) => 2229)
 
 (facts "reads and writes ewkb in hex string"
        (fact "ewkb-hex identity"
@@ -153,12 +154,12 @@
         (get (first (fc "features")) "properties") => {"name" "null island"}))
 
 (fact "parsing geojson defaults to EPSG:4326 but SRID can be overridden in option map"
-      (map (comp jts/get-srid :geometry) (sut/read-geojson geometry)) => [4326]
-      (map (comp jts/get-srid :geometry) (sut/read-geojson feature)) => [4326]
-      (map (comp jts/get-srid :geometry) (sut/read-geojson feature-collection-1)) => [4326]
-      (map (comp jts/get-srid :geometry) (sut/read-geojson geometry 2229)) => [2229]
-      (map (comp jts/get-srid :geometry) (sut/read-geojson feature 2229)) => [2229]
-      (map (comp jts/get-srid :geometry) (sut/read-geojson feature-collection-1 2229)) => [2229])
+      (map (comp crs/get-srid :geometry) (sut/read-geojson geometry)) => [4326]
+      (map (comp crs/get-srid :geometry) (sut/read-geojson feature)) => [4326]
+      (map (comp crs/get-srid :geometry) (sut/read-geojson feature-collection-1)) => [4326]
+      (map (comp crs/get-srid :geometry) (sut/read-geojson geometry 2229)) => [2229]
+      (map (comp crs/get-srid :geometry) (sut/read-geojson feature 2229)) => [2229]
+      (map (comp crs/get-srid :geometry) (sut/read-geojson feature-collection-1 2229)) => [2229])
 
 (fact "convert geometrycollection to features"
       (let [gc (jts/geometry-collection [(sut/read-geojson-geometry null-island-geometry)

--- a/test/geo/t_jts.clj
+++ b/test/geo/t_jts.clj
@@ -58,7 +58,7 @@
 
 (facts "polygons <-> multipolygon"
        (fact "multipolygon to polygons"
-             (str (first (polygons (multi-polygon-wkt [[[-1 -1 11 -1 11 11 -1 -1]],
+             (str (first (geometries (multi-polygon-wkt [[[-1 -1 11 -1 11 11 -1 -1]],
                                                        [[0 0 10 0 10 10 0 0]]]))))
              => "POLYGON ((-1 -1, 11 -1, 11 11, -1 -1))")
        (fact "polygons to multipolygon"
@@ -68,12 +68,12 @@
        (fact "multipolygon SRIDs"
              (-> (multi-polygon [(spatial/to-jts (geohash/geohash "u4pruy"))
                                  (spatial/to-jts (geohash/geohash "u4pruu"))])
-                 get-srid) => 4326
+                 crs/get-srid) => 4326
              (-> (multi-polygon [(spatial/to-jts (geohash/geohash "u4pruy"))
                                  (spatial/to-jts (geohash/geohash "u4pruu"))])
-                 polygons
+                 geometries
                  first
-                 get-srid) => 4326))
+                 crs/get-srid) => 4326))
 
 (facts "geometries <-> geometrycollection"
        (fact "points"
@@ -81,7 +81,7 @@
                                                            (point 1 1)]))))
              => "POINT (0 0)")
        (fact "srids"
-             (get-srid (first (geometries (geometry-collection [(point 0 0 2229)
+             (crs/get-srid (first (geometries (geometry-collection [(point 0 0 2229)
                                                                 (point 0 0 2229)]))))
              => 2229))
 
@@ -121,14 +121,14 @@
        (let [g1 (linestring-wkt [0 0 0 1 0 2])
              g2 (linestring-wkt [1 1 2 2 3 3])
              g3 (linestring-wkt [1 1 2 2 3 3] 1234)]
-         (get-srid g1) => 4326
+         (crs/get-srid g1) => 4326
          (same-srid? g1 g2) => true
          (same-srid? (set-srid g1 0) (set-srid g2 0)) => true
          (same-srid? g1 g3) => false))
 
 (fact "setting SRID for a geom"
-      (get-srid (point 0 0)) => 4326
-      (get-srid (set-srid (point 0 0) 23031)) => 23031)
+      (crs/get-srid (point 0 0)) => 4326
+      (crs/get-srid (set-srid (point 0 0) 23031)) => 23031)
 
 (facts "proj4j"
        (fact "point: 3 param transform"
@@ -177,11 +177,11 @@
                => truthy
                (same-geom? (transform-geom p1 "EPSG:23031") p2)
                => truthy
-               (get-srid (transform-geom p1 23031))
+               (crs/get-srid (transform-geom p1 23031))
                => 23031
-               (get-srid (transform-geom p1 "EPSG:23031"))
+               (crs/get-srid (transform-geom p1 "EPSG:23031"))
                => 23031
-               (get-srid (transform-geom p1 (crs/create-crs 23031)))
+               (crs/get-srid (transform-geom p1 (crs/create-crs 23031)))
                => 23031))
        (fact "If using a different CRS name or proj4 string, SRID is not automatically set"
              (let [p1 (point 3.8142776 51.285914 4326)
@@ -192,9 +192,9 @@
                => truthy))
        (fact "crs/set-srid can take any Transformable"
              (let [p1 (point 10 10 0)]
-               (get-srid (set-srid p1 (crs/create-crs 23031)))
+               (crs/get-srid (set-srid p1 (crs/create-crs 23031)))
                => 23031
-               (get-srid (set-srid p1 (crs/create-crs "EPSG:23031")))
+               (crs/get-srid (set-srid p1 (crs/create-crs "EPSG:23031")))
                => 23031))
        (fact "CRS systems with different names"
              (let [p1 (point 42.3601 -71.0589)

--- a/test/geo/t_jts.clj
+++ b/test/geo/t_jts.clj
@@ -218,7 +218,7 @@
                (same-geom? p2 p3) => true
                (same-geom? p2 p4) => true
                (same-geom? p3 p4) => true))
-       (fact "When passing two CRSs and a GeometryFactory, the factory's SRID will be used."
+       (fact "When passing two CRSs and a GeometryFactory, the GeometryFactory's SRID will be used."
              (let [c1 4326
                    c2 3586
                    s1 (crs/create-crs c1)
@@ -244,4 +244,18 @@
                (same-geom? p4 p4_false) => false
                (same-geom? p2_false p3_false) => true
                (same-geom? p2_false p4_false) => true
-               (same-geom? p3_false p4_false) => true)))
+               (same-geom? p3_false p4_false) => true))
+       (fact "When passing a CoordinateTransform and a GeometryFactory, the GeometryFactory's SRID will be used."
+             (let [c1 4326
+                   c2 3586
+                   f1 (crs/get-geometry-factory 3586)
+                   f2 (crs/get-geometry-factory 4326)
+                   t1 (crs/create-transform 4326 3586)
+                   p1 (point 42.3601 -71.0589)
+                   p2 (transform-geom p1 t1)
+                   p3 (transform-geom p1 t1 f1)
+                   p4 (transform-geom p1 t1 f2)]
+               (crs/get-srid p1) => 4326
+               (crs/get-srid p2) => 3586
+               (crs/get-srid p3) => 3586
+               (crs/get-srid p4) => 4326)))

--- a/test/geo/t_jts.clj
+++ b/test/geo/t_jts.clj
@@ -12,7 +12,7 @@
              (.getX (coordinate 1 2)) => 1.0
              (.getY (coordinate 1 2)) => 2.0
              (Double/isNaN (.getZ (coordinate 1 2))) => true)
-       (fact "XYZ coordinate"
+       (fact "XYZ coordinate"n
              (coordinate 1 2 3) => (Coordinate. 1 2 3)
              (.getX (coordinate 1 2 3)) => 1.0
              (.getY (coordinate 1 2 3)) => 2.0

--- a/test/geo/t_jts.clj
+++ b/test/geo/t_jts.clj
@@ -217,4 +217,31 @@
                (crs/get-srid p4) => 3586
                (same-geom? p2 p3) => true
                (same-geom? p2 p4) => true
-               (same-geom? p3 p4) => true)))
+               (same-geom? p3 p4) => true))
+       (fact "When passing two CRSs and a GeometryFactory, the factory's SRID will be used."
+             (let [c1 4326
+                   c2 3586
+                   s1 (crs/create-crs c1)
+                   s2 (crs/create-crs c2)
+                   f1 (crs/get-geometry-factory 3586)
+                   f_false (crs/get-geometry-factory 9999)
+                   t1 (crs/create-transform 4326 3586)
+                   p1 (point 42.3601 -71.0589)
+                   p2 (transform-geom p1 c1 c2 f1)
+                   p3 (transform-geom p1 s1 s2 f1)
+                   p4 (transform-geom p1 t1 f1)
+                   p2_false (transform-geom p1 c1 c2 f_false)
+                   p3_false (transform-geom p1 s1 s2 f_false)
+                   p4_false (transform-geom p1 t1 f_false)]
+               (same-geom? p2 p3) => true
+               (same-geom? p2 p4) => true
+               (same-geom? p3 p4) => true
+               (crs/get-srid p2_false) => 9999
+               (crs/get-srid p3_false) => 9999
+               (crs/get-srid p4_false) => 9999
+               (same-geom? p2 p2_false) => false
+               (same-geom? p3 p3_false) => false
+               (same-geom? p4 p4_false) => false
+               (same-geom? p2_false p3_false) => true
+               (same-geom? p2_false p4_false) => true
+               (same-geom? p3_false p4_false) => true)))

--- a/test/geo/t_jts.clj
+++ b/test/geo/t_jts.clj
@@ -206,4 +206,15 @@
                (.getX (transform-geom p1 "NAD83:2001"))
                => (.getX p2)
                (.getX (transform-geom p1 "+proj=lcc +lat_1=42.68333333333333 +lat_2=41.71666666666667 +lat_0=41 +lon_0=-71.5 +x_0=200000 +y_0=750000 +datum=NAD83 +units=m +no_defs"))
-               => (.getX p2))))
+               => (.getX p2)))
+       (fact "An external GeometryFactory can be passed"
+             (let [p1 (point 42.3601 -71.0589)
+                   p2 (transform-geom p1 3586)
+                   p3 (transform-geom p1 3586 (crs/get-geometry-factory 3586))
+                   p4 (transform-geom p1 3586 (crs/get-geometry-factory p2))]
+               (crs/get-srid p2) => 3586
+               (crs/get-srid p3) => 3586
+               (crs/get-srid p4) => 3586
+               (same-geom? p2 p3) => true
+               (same-geom? p2 p4) => true
+               (same-geom? p3 p4) => true)))

--- a/test/geo/t_jts.clj
+++ b/test/geo/t_jts.clj
@@ -245,6 +245,18 @@
                (same-geom? p2_false p3_false) => true
                (same-geom? p2_false p4_false) => true
                (same-geom? p3_false p4_false) => true))
+       (fact "When passing one Transformable and one GeometryFactory, determine whether
+              Transformable is target or source depending on if Geometry has SRID."
+             (let [g1 (point 42.3601 -71.0589)
+                   g2 (point -71.0589 42.3601 0)
+                   g3 (transform-geom g1 3586)
+                   f1 (crs/get-geometry-factory 4326)
+                   f2 (crs/get-geometry-factory 3586)]
+               (same-geom? (transform-geom g1 3586 f2) g3) => true
+               (same-geom? (transform-geom g2 3586 f2) g3) => false
+               (same-geom? (transform-geom (set-srid g2 4326) 3586 f2) g3) => true
+               (same-geom? (transform-geom g2 3586 f2) g1) => false
+               (same-geom? (set-srid (transform-geom g2 3586 f2) 4326) g1) => true))
        (fact "When passing a CoordinateTransform and a GeometryFactory, the GeometryFactory's SRID will be used."
              (let [c1 4326
                    c2 3586

--- a/test/geo/t_jts.clj
+++ b/test/geo/t_jts.clj
@@ -12,7 +12,7 @@
              (.getX (coordinate 1 2)) => 1.0
              (.getY (coordinate 1 2)) => 2.0
              (Double/isNaN (.getZ (coordinate 1 2))) => true)
-       (fact "XYZ coordinate"n
+       (fact "XYZ coordinate"
              (coordinate 1 2 3) => (Coordinate. 1 2 3)
              (.getX (coordinate 1 2 3)) => 1.0
              (.getY (coordinate 1 2 3)) => 2.0

--- a/test/geo/t_spatial.clj
+++ b/test/geo/t_spatial.clj
@@ -111,7 +111,7 @@
          (fact (g->j j1) => j1)
          (fact (g->j j2) => j2)
          (fact (s/longitude (t->j j1)) =>
-               (roughly (s/longitude j1)))
+               (roughly (s/longitude j1) 0.0001))
          (fact (s/longitude (t->j j2)) =>
                (roughly (s/longitude j2)))))
 

--- a/test/geo/t_spatial.clj
+++ b/test/geo/t_spatial.clj
@@ -244,7 +244,7 @@
        (fact "Splitting complex linestring over max length"
              (let [ls (jts/linestring-wkt long-sample)
                    rs (s/resegment ls 100000)]
-               (s/length ls) => 1316265.356651721
+               (s/length ls) => (roughly 1316265.356651721)
                (->> rs (map s/length) (reduce +)) => (roughly 1316265)
                (->> rs
                     (drop-last 1) ;; last segment just has remaining distance

--- a/test/geo/t_spatial.clj
+++ b/test/geo/t_spatial.clj
@@ -110,7 +110,7 @@
          (fact (s/to-jts cir1) => throws)
 
          ; Attempt to convert GeoCircle to projected JTS.
-         (fact (s/to-jts cir1 crs/default-srid) => throws)))
+         (fact (s/to-jts cir1 crs/gf-wgs84) => throws)))
 
 ; Have some airports
 (let [lhr (s/spatial4j-point 51.477500 -0.461388)

--- a/test/geo/t_spatial.clj
+++ b/test/geo/t_spatial.clj
@@ -53,38 +53,67 @@
              s->j (comp s/to-jts s/to-spatial4j-point)
              j->g (comp s/to-geohash-point s/to-jts)
              g->j (comp s/to-jts s/to-geohash-point)
+             g->t (comp #(s/to-jts % 3586) s/to-geohash-point)
+             t->g (comp s/to-geohash-point #(s/to-jts % 3586))
+             s->t (comp #(s/to-jts % 3586) s/to-spatial4j-point)
+             t->s (comp s/to-spatial4j-point #(s/to-jts % 3586))
+             j->t (comp #(s/to-jts % 3586) #(s/to-jts % 4326))
+             t->j (comp #(s/to-jts % 4326) #(s/to-jts % 3586))
              g1 (s/geohash-point 0 0)
              g2 (s/geohash-point 12.456 -98.765)
              s1 (s/spatial4j-point 0 0)
              s2 (s/spatial4j-point 12.456 -98.765)
              j1 (s/jts-point 0 0)
-             j2 (s/jts-point 12.456 -98.765)]
+             j2 (s/jts-point 12.456 -98.765)
+             t1 (jts/transform-geom j1 3586)
+             t2 (jts/transform-geom j2 3586)]
          ; Identity conversions
          (fact (s/to-geohash-point g2) => g2)
          (fact (s/to-spatial4j-point g2) => s2)
          (fact (s/to-jts j2) => j2)
+         (fact (s/latitude (s/to-jts t2 3586)) =>
+               (roughly (s/latitude t2)))
 
          ; Direct conversions
          (fact (s/to-spatial4j-point g2) => s2)
          (fact (s/to-spatial4j-point j2) => s2)
+         (fact (s/latitude (s/to-spatial4j-point t2)) =>
+               (roughly (s/latitude s2)))
          (fact (s/to-geohash-point s2) => g2)
-         (fact (s/to-geohash-point j2) => g2)
+         (fact (s/latitude (s/to-geohash-point j2)) =>
+               (s/latitude g2))
          (fact (s/to-jts s2) => j2)
          (fact (s/to-jts g2) => j2)
+         (fact (s/to-jts t2) => t2)
+         (fact (s/to-jts g2 3586) => t2)
+         (fact (s/to-jts s2 3586) => t2)
+         (fact (s/to-jts j2 3586) => t2)
 
          ; Two-way conversions
          (fact (s->g g1) => g1)
          (fact (s->g g2) => g2)
          (fact (j->g g1) => g1)
          (fact (j->g g2) => g2)
+         (fact (s/latitude (t->g g1)) =>
+               (roughly (s/latitude g1)))
+         (fact (s/latitude (t->g g2)) =>
+               (roughly (s/latitude g2)))
          (fact (g->s s1) => s1)
          (fact (g->s s2) => s2)
          (fact (j->s s1) => s1)
          (fact (j->s s2) => s2)
+         (fact (s/latitude (t->s s1)) =>
+               (roughly (s/latitude s1)))
+         (fact (s/latitude (t->s s2)) =>
+               (roughly (s/latitude s2)))
          (fact (s->j j1) => j1)
          (fact (s->j j2) => j2)
          (fact (g->j j1) => j1)
-         (fact (g->j j2) => j2)))
+         (fact (g->j j2) => j2)
+         (fact (s/longitude (t->j j1)) =>
+               (roughly (s/longitude j1)))
+         (fact (s/longitude (t->j j2)) =>
+               (roughly (s/longitude j2)))))
 
 (facts "interchangeable polygons"
        (let [s->j (comp s/to-jts s/to-shape)

--- a/test/geo/t_spatial.clj
+++ b/test/geo/t_spatial.clj
@@ -1,5 +1,6 @@
 (ns geo.t-spatial
-  (:require [geo.jts :as jts]
+  (:require [geo.crs :as crs]
+            [geo.jts :as jts]
             [geo.spatial :as s]
             [geo.geohash :refer :all]
             [midje.sweet :refer [fact facts falsey future-fact n-of roughly throws truthy]])
@@ -109,7 +110,7 @@
          (fact (s/to-jts cir1) => throws)
 
          ; Attempt to convert GeoCircle to projected JTS.
-         (fact (s/to-jts cir1 jts/default-srid) => throws)))
+         (fact (s/to-jts cir1 crs/default-srid) => throws)))
 
 ; Have some airports
 (let [lhr (s/spatial4j-point 51.477500 -0.461388)


### PR DESCRIPTION
After reworking `set-srid` to [use `GeometryFactory` methods instead of `.setSrid`](https://locationtech.github.io/jts/javadoc/org/locationtech/jts/geom/Geometry.html#setSRID-int-), I realized that there was unnecessary churn both in terms of now-unnecessary `set-srid` checks at the end of transformations as well as transformations back and forth from `GeometryFactory` to `SRID`. By moving `get-geometry-factory` to `Transformable` and extending it to `Geometry` and `GeometryFactory`, a lot of functionality can be simplified and de-duplicated.

For this reason, beyond the changes to `Transformable`, I think that a few `def`s in `geo.jts` should be moved to `geo.crs` and deprecated. Additionally, `polygons` is actually exactly the same as `geometries`, so it should be deprecated too.

Everything still works the same as in 3.0.1 for the end user, but the notes in the changelog do suggest moving away from these deprecated functions.

@worace Let me know if this looks good to you. If so, I can merge and push out a 3.0.2.