### PR TITLE
Remove singularity issue at poles by providing spatial4j dist calc

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 * Bump `geohash` to 1.4.0, which can use bounding boxes over the meridian
 * For development, bump `lein-midje` to 3.2.2 and `jackson` to 2.10.2
 * Bump `h3` to 3.6.3
+* Remove singularity error with `distance` by using spheroidal `spatial4j` Vincenty calculation when input point is at a pole, but otherwise using the `geohash` ellipsoidal Vincenty calculation.
 
 ## 3.0.0 to 3.0.1
 

--- a/README.md
+++ b/README.md
@@ -25,10 +25,7 @@ In addition, we provide common scales and translation functions for unit
 conversion: converting between steradians and surface areas; finding the radius
 along the geoid, and some basic properties.
 
-This library is incomplete; in particular, it is not as fast as it could be,
-encounters bounded errors when translating between various geoid
-representations, and is subject to singularities at the poles. Nonetheless, we
-hope that it can be a canonical resource for geospatial computation in Clojure.
+We hope that it can be a canonical resource for geospatial computation in Clojure.
 
 # Installation
 

--- a/src/geo/spatial.clj
+++ b/src/geo/spatial.clj
@@ -292,8 +292,8 @@
   ; algorithm, which causes distances at the poles to return
   ; bad results. In these cases, use spatial4j's spherical vincenty
   ; distance calculator.
- (if (and (not= (double (abs (latitude a))) 90.0)
-          (not= (double (abs (latitude b))) 90.0))
+ (if (and (<= (abs (latitude a)) 89.99999999999999)
+          (<= (abs (latitude b)) 89.99999999999999))
     (VincentyGeodesy/distanceInMeters
      (to-geohash-point a)
      (to-geohash-point b))

--- a/test/geo/t_spatial.clj
+++ b/test/geo/t_spatial.clj
@@ -124,16 +124,14 @@
       sfo-oak 17734]
   ; See http://www.gcmap.com/dist?P=LHR-SYD%2CSYD-LAX%2CLHR-LAX%0D%0A&DU=m&DM=&SG=&SU=mph
   (facts "distance in meters"
-         ; This breaks VincentyGeodesy from the geohash library; there's a
-         ; singularity at the poles.
-         (future-fact (s/distance (geohash-point 89.999, 0)
-                         (geohash-point 90.0, 0))
-               => 1.234567)
+         (fact (s/distance (s/geohash-point 89.99999, 0)
+                           (s/geohash-point 90.0, 0))
+               => (roughly 1.112))
          (fact (s/distance lhr syd) => (roughly lhr-syd))
          (fact (s/distance syd lax) => (roughly syd-lax))
          (fact (s/distance lax lhr) => (roughly lax-lhr))
          (fact (s/distance (s/geohash-point sfo)
-                         (s/geohash-point oak)) => (roughly sfo-oak)))
+                           (s/geohash-point oak)) => (roughly sfo-oak)))
 
   (facts "intersections"
          (fact "A circle around a point intersects that point."

--- a/test/geo/t_spatial.clj
+++ b/test/geo/t_spatial.clj
@@ -124,9 +124,15 @@
       sfo-oak 17734]
   ; See http://www.gcmap.com/dist?P=LHR-SYD%2CSYD-LAX%2CLHR-LAX%0D%0A&DU=m&DM=&SG=&SU=mph
   (facts "distance in meters"
-         (fact (s/distance (s/geohash-point 89.99999, 0)
-                           (s/geohash-point 90.0, 0))
-               => (roughly 1.112))
+         (fact (s/distance (s/geohash-point 89.999999999999990 0)
+                           (s/geohash-point 89.999999999999978 0))
+               => (roughly 1.4E-9 1E-10))
+         (fact (s/distance (s/geohash-point 89.9999999999999999 0)
+                           (s/geohash-point 89.9999999999999920 0))
+               => (roughly 1.4E-9 1E-10))
+         (fact (s/distance (s/geohash-point 89.99999999999999999 0)
+                           (s/geohash-point 89.99999999999999289 0))
+               => (roughly 1.4E-9 1E-10))
          (fact (s/distance lhr syd) => (roughly lhr-syd))
          (fact (s/distance syd lax) => (roughly syd-lax))
          (fact (s/distance lax lhr) => (roughly lax-lhr))


### PR DESCRIPTION
While the distance function in `geohash` continues to have the issue at the poles that led to the `future-fact` caveat on the distance calculation, a way to address it is to use the `spatial4j` spheroidal distance calculator that was added for `rand-point-in-radius` as a less-accurate fallback in situations where one of the input points is at the poles.

With this, alongside the fixed dateline issues for spatial4j, and type reflection hints, I think the "incomplete" note in the README can finally be removed.

@worace 